### PR TITLE
Revert "Bump junit from 4.13 to 4.13.2 in /hdt-qs-backend"

### DIFF
--- a/hdt-qs-backend/pom.xml
+++ b/hdt-qs-backend/pom.xml
@@ -17,7 +17,7 @@
 
         <common_codec.version>1.15</common_codec.version>
         <json_simple.version>1.1.1</json_simple.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>4.13</junit.version>
         <lwjgl.version>3.3.1</lwjgl.version>
         <rdf4j.version>4.0.0</rdf4j.version>
         <rdfhdt.version>3.0.2</rdfhdt.version>


### PR DESCRIPTION
Reverts the-qa-company/qEndpoint#4, the tests weren't passing, but without triggering an error