### PR TITLE
GH-34 disable reindex button if no Lucene sail is connected to the endpoint

### DIFF
--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/compiler/CompiledSail.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/compiler/CompiledSail.java
@@ -173,6 +173,13 @@ public class CompiledSail extends SailWrapper {
 	}
 
 	/**
+	 * @return if the sail has a least one lucene sail connected to it
+	 */
+	public boolean hasLuceneSail() {
+		return !luceneSails.isEmpty();
+	}
+
+	/**
 	 * Compiler class for the
 	 * {@link com.the_qa_company.qendpoint.compiler.CompiledSail}
 	 *

--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
@@ -114,6 +114,13 @@ public class SparqlRepository {
 	}
 
 	/**
+	 * @return if the sail has a least one lucene sail connected to it
+	 */
+	public boolean hasLuceneSail() {
+		return compiledSail.hasLuceneSail();
+	}
+
+	/**
 	 * execute a sparql query
 	 *
 	 * @param sparqlQuery  the query

--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
@@ -157,6 +157,11 @@ public class EndpointController {
 		return ResponseEntity.status(HttpStatus.OK).body(sparql.reindexLucene());
 	}
 
+	@GetMapping("/has_index")
+	public ResponseEntity<Sparql.HasLuceneIndexResult> hasIndex() {
+		return ResponseEntity.status(HttpStatus.OK).body(sparql.hasLuceneSail());
+	}
+
 	@GetMapping("/is_merging")
 	public ResponseEntity<Sparql.IsMergingResult> isMerging() {
 		return ResponseEntity.status(HttpStatus.OK).body(sparql.isMerging());

--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
@@ -70,6 +70,18 @@ public class Sparql implements CommandLineRunner {
 		}
 	}
 
+	public static class HasLuceneIndexResult {
+		private final boolean hasLuceneIndex;
+
+		public HasLuceneIndexResult(boolean hasLuceneIndex) {
+			this.hasLuceneIndex = hasLuceneIndex;
+		}
+
+		public boolean isHasLuceneIndex() {
+			return hasLuceneIndex;
+		}
+	}
+
 	public static class IsMergingResult {
 		private final boolean merging;
 
@@ -179,6 +191,7 @@ public class Sparql implements CommandLineRunner {
 
 	/**
 	 * Init the endpoint
+	 *
 	 * @throws IOException exception with the initialization
 	 */
 	public void init() throws IOException {
@@ -205,6 +218,7 @@ public class Sparql implements CommandLineRunner {
 
 	/**
 	 * shutdown the endpoint
+	 *
 	 * @throws IOException io exception
 	 */
 	@PreDestroy
@@ -301,6 +315,13 @@ public class Sparql implements CommandLineRunner {
 		initializeEndpointStore(true);
 		sparqlRepository.reindexLuceneSails();
 		return new LuceneIndexRequestResult(true);
+	}
+
+	/**
+	 * @return if the sail has a least one lucene sail connected to it
+	 */
+	public HasLuceneIndexResult hasLuceneSail() {
+		return new HasLuceneIndexResult(sparqlRepository.hasLuceneSail());
 	}
 
 	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,

--- a/hdt-qs-frontend/src/components/Control/index.tsx
+++ b/hdt-qs-frontend/src/components/Control/index.tsx
@@ -112,6 +112,8 @@ export default function Control () {
     return false
   }, [isMerging, isMergingReq.loading, isMergingReq.rawRequest])
 
+  const dontShowIndexButton = !indexReq.loading && (hasIndexReq.loading || (hasIndexReq.success && hasIndex === false))
+
   return (
     <div className={s.container}>
       <div className={s.centered}>
@@ -139,15 +141,16 @@ export default function Control () {
             </LoadingButton>
           </Tooltip>
 
-          <LoadingButton
-            variant='contained'
-            startIcon={<ListIcon />}
-            loading={indexReq.loading}
-            disabled={!indexReq.loading && (hasIndexReq.loading || (hasIndexReq.success && hasIndex === false))}
-            onClick={index}
-          >
-            Re-Index
-          </LoadingButton>
+          {!dontShowIndexButton && (
+            <LoadingButton
+              variant='contained'
+              startIcon={<ListIcon />}
+              loading={indexReq.loading}
+              onClick={index}
+            >
+              Re-Index
+            </LoadingButton>
+          )}
         </div>
       </div>
     </div>

--- a/hdt-qs-frontend/src/components/Control/index.tsx
+++ b/hdt-qs-frontend/src/components/Control/index.tsx
@@ -17,6 +17,32 @@ export default function Control () {
 
   const [isMerging, setIsMerging] = useState<boolean>()
   const [isMergingTooltipVisible, setIsMergingTooltipVisible] = useState(false)
+  const [hasIndex, setHasIndex] = useState<boolean>()
+
+  // hasIndex request
+  const hasIndexReq = useFastAPI({ autoNotify: true, errorMsg: 'Impossible to know if the endpoint has an index' })
+  const {
+    setRequest: setHasIndexRequest
+  } = hasIndexReq
+
+  const checkHasIndex = useCallback(() => {
+    setHasIndexRequest(fetch(`${config.apiBase}/endpoint/has_index`))
+  }, [setHasIndexRequest])
+
+  // Make hasIndex request on mount
+  useEffect(() => {
+    checkHasIndex()
+  }, [checkHasIndex])
+
+  // Read hasIndex response
+  useAsyncEffect(async () => {
+    if (hasIndexReq.success && hasIndexReq.res !== undefined) {
+      const parsed = await hasIndexReq.res.json()
+      if (typeof parsed.hasLuceneIndex === 'boolean') {
+        setHasIndex(parsed.hasLuceneIndex)
+      }
+    }
+  }, [hasIndexReq.success, hasIndexReq.res])
 
   // isMerging request
   const isMergingReq = useFastAPI({ autoNotify: true, errorMsg: 'Impossible to know whether the endpoint is merging or not' })
@@ -37,7 +63,6 @@ export default function Control () {
   useAsyncEffect(async () => {
     if (isMergingReq.success && isMergingReq.res !== undefined) {
       const parsed = await isMergingReq.res.json()
-      console.log('parsed', parsed)
       setIsMerging(parsed.merging)
     }
   }, [isMergingReq.success, isMergingReq.res])
@@ -118,6 +143,7 @@ export default function Control () {
             variant='contained'
             startIcon={<ListIcon />}
             loading={indexReq.loading}
+            disabled={!indexReq.loading && (hasIndexReq.loading || (hasIndexReq.success && hasIndex === false))}
             onClick={index}
           >
             Re-Index


### PR DESCRIPTION
Issue resolved (if any): #34

Description of this pull request:

Disable the reindex button by adding the `/has_index` method in the API and linking it to the front-end

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
