### PR TITLE
GH-42 set the same origin in the frontend in production env

### DIFF
--- a/.github/workflows/quick_compile.yml
+++ b/.github/workflows/quick_compile.yml
@@ -1,0 +1,43 @@
+name: Quick compile
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version_get.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: version_get
+        run: echo "::set-output name=version::$(scripts/get_version.sh)"
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache-dependency-path: hdt-qs-frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: npm ci --legacy-peer-deps
+        working-directory: hdt-qs-frontend
+      - name: Compiling frontend
+        run: npm run build --if-present
+        working-directory: hdt-qs-frontend
+      - name: Put frontend in backend
+        run: |
+          mkdir -p hdt-qs-backend/src/main/resources/static/
+          cp -r hdt-qs-frontend/build/* hdt-qs-backend/src/main/resources/static/
+      - name: Compile backend
+        run: mvn install -DskipTests
+        working-directory: hdt-qs-backend
+      - name: move endpoint
+        run: mv hdt-qs-backend/target/qendpoint-*-exec.jar endpoint.jar
+      - name: Deploy jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: "endpoint.jar"
+          path: "endpoint.jar"
+

--- a/.github/workflows/quick_compile.yml
+++ b/.github/workflows/quick_compile.yml
@@ -1,6 +1,6 @@
 name: Quick compile
 
-on: workflow_dispatch
+on: [workflow_dispatch, push]
 
 jobs:
   build:

--- a/hdt-qs-frontend/package.json
+++ b/hdt-qs-frontend/package.json
@@ -6,7 +6,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "REACT_APP_DEV=true PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/hdt-qs-frontend/src/common/config/config.json
+++ b/hdt-qs-frontend/src/common/config/config.json
@@ -1,4 +1,4 @@
 {
-  "apiBase": "http://localhost:1234/api",
+  "apiBaseDev": "http://localhost:1234/api",
   "aboutPage": "https://qanswer.ai/"
 }

--- a/hdt-qs-frontend/src/common/config/index.ts
+++ b/hdt-qs-frontend/src/common/config/index.ts
@@ -1,3 +1,17 @@
 import config from './config.json'
 
-export default config
+const dev = process.env.REACT_APP_DEV === 'true'
+
+let apiBase: String
+
+if (dev) {
+  apiBase = config.apiBaseDev
+} else {
+  apiBase = window.location.origin + '/api'
+}
+
+export default {
+  ...config,
+  dev,
+  apiBase
+}


### PR DESCRIPTION
Issue resolved (if any): #42 

Description of this pull request:

Will use the origin of the backend to get the api base if we are not in dev env.

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
