### PR TITLE
GH-108 Fix FormatUtils' header methods

### DIFF
--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/utils/FormatUtils.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/utils/FormatUtils.java
@@ -5,7 +5,11 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterRegistry;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Utility class to get response format
@@ -13,6 +17,34 @@ import java.util.Optional;
  * @author Antoine Willerval
  */
 public class FormatUtils {
+	private static class ValuedMime {
+		float value;
+		String mime;
+
+		public ValuedMime(float value, String mime) {
+			this.value = value;
+			this.mime = mime;
+		}
+	}
+
+	private static Stream<ValuedMime> sortedFormat(String acceptHeader) {
+
+		List<ValuedMime> mimes = new ArrayList<>();
+
+		for (String acceptedType : acceptHeader.split("[,]")) {
+			String[] split = acceptedType.split(";");
+
+			String mime = split[0];
+			float value;
+			if (split.length != 1 && split[1].startsWith("q=")) {
+				value = Float.parseFloat(split[1].substring(2));
+			} else {
+				value = 1;
+			}
+			mimes.add(new ValuedMime(value, mime));
+		}
+		return mimes.stream().sorted(Comparator.<ValuedMime>comparingDouble(m -> m.value).reversed());
+	}
 
 	/**
 	 * get a result writer format for an accept header
@@ -21,14 +53,9 @@ public class FormatUtils {
 	 * @return the format
 	 */
 	public static Optional<QueryResultFormat> getResultWriterFormat(String acceptHeader) {
-		for (String mime : acceptHeader.split("[,;]")) {
-			Optional<QueryResultFormat> format = TupleQueryResultWriterRegistry.getInstance()
-					.getFileFormatForMIMEType(mime);
-			if (format.isPresent()) {
-				return format;
-			}
-		}
-		return Optional.empty();
+		return sortedFormat(acceptHeader)
+				.map(m -> TupleQueryResultWriterRegistry.getInstance().getFileFormatForMIMEType(m.mime))
+				.filter(Optional::isPresent).map(Optional::get).findFirst();
 	}
 
 	/**
@@ -38,12 +65,7 @@ public class FormatUtils {
 	 * @return the format
 	 */
 	public static Optional<RDFFormat> getRDFWriterFormat(String acceptHeader) {
-		for (String mime : acceptHeader.split("[,;]")) {
-			Optional<RDFFormat> format = Rio.getWriterFormatForMIMEType(mime);
-			if (format.isPresent()) {
-				return format;
-			}
-		}
-		return Optional.empty();
+		return sortedFormat(acceptHeader).map(m -> Rio.getWriterFormatForMIMEType(m.mime)).filter(Optional::isPresent)
+				.map(Optional::get).findFirst();
 	}
 }

--- a/hdt-qs-backend/src/test/java/com/the_qa_company/qendpoint/utils/FormatUtilsTest.java
+++ b/hdt-qs-backend/src/test/java/com/the_qa_company/qendpoint/utils/FormatUtilsTest.java
@@ -1,0 +1,41 @@
+package com.the_qa_company.qendpoint.utils;
+
+import org.eclipse.rdf4j.query.resultio.QueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FormatUtilsTest {
+
+	@Test
+	public void getResultWriterFormat() {
+		assertEquals(TupleQueryResultFormat.JSON,
+				FormatUtils
+						.getResultWriterFormat(
+								"text/csv;q=0.8,application/sparql-results+json,text/tab-separated-values;q=0.8")
+						.orElseThrow());
+		assertEquals(TupleQueryResultFormat.TSV,
+				FormatUtils
+						.getResultWriterFormat(
+								"text/csv;q=0.8,application/sparql-results+json;q=0.8,text/tab-separated-values;q=0.9")
+						.orElseThrow());
+		assertEquals(TupleQueryResultFormat.CSV,
+				FormatUtils
+						.getResultWriterFormat(
+								"text/csv,application/sparql-results+json;q=0.8,text/tab-separated-values;q=0.9")
+						.orElseThrow());
+	}
+
+	@Test
+	public void getRDFWriterFormat() {
+		assertEquals(RDFFormat.RDFJSON, FormatUtils
+				.getRDFWriterFormat("text/turtle;q=0.8,application/rdf+json,application/trig;q=0.8").orElseThrow());
+		assertEquals(RDFFormat.TRIG,
+				FormatUtils.getRDFWriterFormat("text/turtle;q=0.8,application/rdf+json;q=0.8,application/trig;q=0.9")
+						.orElseThrow());
+		assertEquals(RDFFormat.TURTLE, FormatUtils
+				.getRDFWriterFormat("text/turtle,application/rdf+json;q=0.8,application/trig;q=0.9").orElseThrow());
+	}
+}


### PR DESCRIPTION
Issue resolved (if any): #108 

Description of this pull request:

Allow to use q= in the accept header

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
