### PR TITLE
GH-270 Add converter to convert HDT dictionaries

### DIFF
--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/store/EndpointFiles.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/store/EndpointFiles.java
@@ -64,6 +64,25 @@ public class EndpointFiles {
 	}
 
 	/**
+	 * create a file getter for a store
+	 *
+	 * @param locationEndpoint the qendpoint location dir
+	 * @param hdtIndexName     the hdt index name
+	 */
+	public EndpointFiles(Path locationEndpoint, String hdtIndexName) {
+		this(locationEndpoint.resolve("native-store"), locationEndpoint.resolve("hdt-store"), hdtIndexName);
+	}
+
+	/**
+	 * create a file getter for a store
+	 *
+	 * @param locationEndpoint the qendpoint location dir
+	 */
+	public EndpointFiles(Path locationEndpoint) {
+		this(locationEndpoint, "index_dev.hdt");
+	}
+
+	/**
 	 * @return path of {@link #getLocationHdt()}
 	 */
 	public Path getLocationHdtPath() {

--- a/qendpoint-cli/bin/hdtconvert.bat
+++ b/qendpoint-cli/bin/hdtconvert.bat
@@ -1,0 +1,5 @@
+@echo off
+
+call "%~dp0\javaenv.bat"
+
+"%JAVACMD%" -XX:NewRatio=1 -XX:SurvivorRatio=9 %JAVAOPTIONS% -classpath %~dp0\..\lib\* com.the_qa_company.qendpoint.core.tools.HDTConvertTool %*

--- a/qendpoint-cli/bin/hdtconvert.ps1
+++ b/qendpoint-cli/bin/hdtconvert.ps1
@@ -1,0 +1,28 @@
+param(
+    [Parameter()]
+    [String]
+    $options,
+    [Parameter()]
+    [String]
+    $config,
+    [Parameter()]
+    [Switch]
+    $color,
+    [Parameter()]
+    [Switch]
+    $version,
+    [Parameter()]
+    [Switch]
+    $dict,
+    [Parameter()]
+    [Switch]
+    $quiet,
+    [Parameter()]
+    [Switch]
+    $load,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "com.the_qa_company.qendpoint.core.tools.HDTConvertTool" -RequiredParameters $PSBoundParameters

--- a/qendpoint-cli/bin/hdtconvert.sh
+++ b/qendpoint-cli/bin/hdtconvert.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source `dirname $0`/javaenv.sh
+
+$JAVA $JAVA_OPTIONS -cp $CP:$CLASSPATH -XX:NewRatio=1 -XX:SurvivorRatio=9 com.the_qa_company.qendpoint.core.tools.HDTConvertTool $*
+
+exit $?

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/dictionary/impl/MultipleSectionDictionary.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/dictionary/impl/MultipleSectionDictionary.java
@@ -1,5 +1,6 @@
 package com.the_qa_company.qendpoint.core.dictionary.impl;
 
+import com.the_qa_company.qendpoint.core.compact.integer.VByte;
 import com.the_qa_company.qendpoint.core.dictionary.DictionarySection;
 import com.the_qa_company.qendpoint.core.dictionary.DictionarySectionPrivate;
 import com.the_qa_company.qendpoint.core.dictionary.TempDictionary;
@@ -8,16 +9,15 @@ import com.the_qa_company.qendpoint.core.dictionary.impl.section.PFCDictionarySe
 import com.the_qa_company.qendpoint.core.exceptions.IllegalFormatException;
 import com.the_qa_company.qendpoint.core.hdt.HDTVocabulary;
 import com.the_qa_company.qendpoint.core.header.Header;
+import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
+import com.the_qa_company.qendpoint.core.iterator.utils.PeekIterator;
+import com.the_qa_company.qendpoint.core.iterator.utils.StopIterator;
 import com.the_qa_company.qendpoint.core.listener.ProgressListener;
 import com.the_qa_company.qendpoint.core.options.ControlInfo;
 import com.the_qa_company.qendpoint.core.options.ControlInformation;
 import com.the_qa_company.qendpoint.core.options.HDTOptions;
 import com.the_qa_company.qendpoint.core.util.CustomIterator;
 import com.the_qa_company.qendpoint.core.util.LiteralsUtils;
-import com.the_qa_company.qendpoint.core.compact.integer.VByte;
-import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
-import com.the_qa_company.qendpoint.core.iterator.utils.PeekIterator;
-import com.the_qa_company.qendpoint.core.iterator.utils.StopIterator;
 import com.the_qa_company.qendpoint.core.util.concurrent.ExceptionThread;
 import com.the_qa_company.qendpoint.core.util.io.CountInputStream;
 import com.the_qa_company.qendpoint.core.util.io.IOUtil;
@@ -47,6 +47,16 @@ public class MultipleSectionDictionary extends MultipleBaseDictionary {
 		predicates = new PFCDictionarySection(spec);
 		objects = new TreeMap<>(CharSequenceComparator.getInstance());
 		shared = new PFCDictionarySection(spec);
+	}
+
+	public MultipleSectionDictionary(HDTOptions spec, DictionarySectionPrivate subjects,
+			DictionarySectionPrivate predicates, TreeMap<ByteString, DictionarySectionPrivate> objects,
+			DictionarySectionPrivate shared) {
+		super(spec);
+		this.subjects = subjects;
+		this.predicates = predicates;
+		this.objects = objects;
+		this.shared = shared;
 	}
 
 	/*

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/dictionary/impl/UnmodifiableDictionarySectionPrivate.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/dictionary/impl/UnmodifiableDictionarySectionPrivate.java
@@ -1,0 +1,80 @@
+package com.the_qa_company.qendpoint.core.dictionary.impl;
+
+import com.the_qa_company.qendpoint.core.dictionary.DictionarySection;
+import com.the_qa_company.qendpoint.core.dictionary.DictionarySectionPrivate;
+import com.the_qa_company.qendpoint.core.dictionary.TempDictionarySection;
+import com.the_qa_company.qendpoint.core.exceptions.NotImplementedException;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Iterator;
+
+/**
+ * Implementation of {@link DictionarySectionPrivate} from a
+ * {@link DictionarySection}, if the section isn't private, all the private
+ * operations will return a {@link NotImplementedException}
+ *
+ * @author Antoine Willerval
+ */
+public class UnmodifiableDictionarySectionPrivate implements DictionarySectionPrivate {
+
+	public static DictionarySectionPrivate of(DictionarySection handle) {
+		if (handle instanceof DictionarySectionPrivate) {
+			return (DictionarySectionPrivate) handle;
+		}
+		return new UnmodifiableDictionarySectionPrivate(handle);
+	}
+
+	private final DictionarySection wrapper;
+
+	private UnmodifiableDictionarySectionPrivate(DictionarySection wrapper) {
+		this.wrapper = wrapper;
+	}
+
+	@Override
+	public long locate(CharSequence s) {
+		return wrapper.locate(s);
+	}
+
+	@Override
+	public CharSequence extract(long pos) {
+		return wrapper.extract(pos);
+	}
+
+	@Override
+	public long size() {
+		return wrapper.size();
+	}
+
+	@Override
+	public long getNumberOfElements() {
+		return wrapper.getNumberOfElements();
+	}
+
+	@Override
+	public Iterator<? extends CharSequence> getSortedEntries() {
+		return wrapper.getSortedEntries();
+	}
+
+	@Override
+	public void close() throws IOException {
+		wrapper.close();
+	}
+
+	@Override
+	public void load(TempDictionarySection other, ProgressListener listener) {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void save(OutputStream output, ProgressListener listener) throws IOException {
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public void load(InputStream input, ProgressListener listener) throws IOException {
+		throw new NotImplementedException();
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/enums/TripleComponentOrder.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/enums/TripleComponentOrder.java
@@ -26,29 +26,52 @@ public enum TripleComponentOrder {
 	/**
 	 * Subject, predicate, object
 	 */
-	Unknown,
+	Unknown(null, null, null),
 	/**
 	 * Subject, predicate, object
 	 */
-	SPO,
+	SPO(TripleComponentRole.SUBJECT, TripleComponentRole.PREDICATE, TripleComponentRole.OBJECT),
 	/**
 	 * Subject, object, predicate
 	 */
-	SOP,
+	SOP(TripleComponentRole.SUBJECT, TripleComponentRole.OBJECT, TripleComponentRole.PREDICATE),
 	/**
 	 * Predicate, subject, object
 	 */
-	PSO,
+	PSO(TripleComponentRole.PREDICATE, TripleComponentRole.SUBJECT, TripleComponentRole.OBJECT),
 	/**
 	 * Predicate, object, subject
 	 */
-	POS,
+	POS(TripleComponentRole.PREDICATE, TripleComponentRole.OBJECT, TripleComponentRole.SUBJECT),
 	/**
 	 * Object, subject, predicate
 	 */
-	OSP,
+	OSP(TripleComponentRole.OBJECT, TripleComponentRole.SUBJECT, TripleComponentRole.PREDICATE),
 	/**
 	 * Object, predicate, subject
 	 */
-	OPS,
+	OPS(TripleComponentRole.OBJECT, TripleComponentRole.PREDICATE, TripleComponentRole.SUBJECT);
+
+	private final TripleComponentRole subjectMapping;
+	private final TripleComponentRole predicateMapping;
+	private final TripleComponentRole objectMapping;
+
+	TripleComponentOrder(TripleComponentRole subjectMapping, TripleComponentRole predicateMapping,
+			TripleComponentRole objectMapping) {
+		this.subjectMapping = subjectMapping;
+		this.predicateMapping = predicateMapping;
+		this.objectMapping = objectMapping;
+	}
+
+	public TripleComponentRole getSubjectMapping() {
+		return subjectMapping;
+	}
+
+	public TripleComponentRole getPredicateMapping() {
+		return predicateMapping;
+	}
+
+	public TripleComponentRole getObjectMapping() {
+		return objectMapping;
+	}
 }

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/Converter.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/Converter.java
@@ -1,0 +1,72 @@
+package com.the_qa_company.qendpoint.core.hdt;
+
+import com.the_qa_company.qendpoint.core.hdt.impl.converter.FSDToMSDConverter;
+import com.the_qa_company.qendpoint.core.hdt.impl.converter.MSDToFSDConverter;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Class to convert a current HDT on disk to another one with another dict type
+ *
+ * @author Antoine Willerval
+ */
+public interface Converter {
+	/**
+	 * create a Converter for this HDT to a new type
+	 *
+	 * @param origin  origin HDT
+	 * @param newType new type {@link Converter}
+	 * @return Converter
+	 */
+	static Converter newConverter(HDT origin, String newType) {
+		Objects.requireNonNull(origin, "origin can't be null!");
+
+		String oldType = origin.getDictionary().getType();
+
+		switch (oldType) {
+		case HDTVocabulary.DICTIONARY_TYPE_MULT_SECTION, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS -> {
+			if (newType.equals(HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION)) {
+				return new MSDToFSDConverter();
+			}
+		}
+		case HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION -> {
+			switch (newType) {
+			case HDTVocabulary.DICTIONARY_TYPE_MULT_SECTION, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS -> {
+				return new FSDToMSDConverter();
+			}
+			}
+		}
+		}
+
+		throw new IllegalArgumentException("Can't find Converter for types " + oldType + " => " + newType);
+	}
+
+	/**
+	 * @return future type
+	 */
+	String getDestinationType();
+
+	/**
+	 * convert the HDT at location origin to a new HDT at location destination
+	 *
+	 * @param origin      origin HDT
+	 * @param destination destination HDT
+	 */
+	void convertHDTFile(HDT origin, Path destination, ProgressListener listener, HDTOptions options) throws IOException;
+
+	/**
+	 * convert the HDT at location origin to a new HDT at location destination
+	 *
+	 * @param origin      origin HDT
+	 * @param destination destination HDT
+	 */
+	default void convertHDTFile(HDT origin, String destination, ProgressListener listener, HDTOptions options)
+			throws IOException {
+		convertHDTFile(origin, Path.of(destination), listener, options);
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/HDT.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/HDT.java
@@ -22,6 +22,7 @@ package com.the_qa_company.qendpoint.core.hdt;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 
 import com.the_qa_company.qendpoint.core.dictionary.Dictionary;
 import com.the_qa_company.qendpoint.core.header.Header;
@@ -76,6 +77,18 @@ public interface HDT extends RDFAccess, Closeable {
 	 * @throws IOException when the file cannot be found
 	 */
 	void saveToHDT(String fileName, ProgressListener listener) throws IOException;
+
+	/**
+	 * Saves to a file in HDT format
+	 *
+	 * @param fileName The OutputStream to save to
+	 * @param listener A listener that can be used to see the progress of the
+	 *                 saving
+	 * @throws IOException when the file cannot be found
+	 */
+	default void saveToHDT(Path fileName, ProgressListener listener) throws IOException {
+		saveToHDT(fileName.toAbsolutePath().toString(), listener);
+	}
 
 	/**
 	 * Returns the size of the Data Structure in bytes.

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/HDTManagerImpl.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/HDTManagerImpl.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 
@@ -44,6 +45,10 @@ public class HDTManagerImpl extends HDTManager {
 	@Override
 	public HDTOptions doReadOptions(String file) throws IOException {
 		return new HDTSpecification(file);
+	}
+
+	public static HDT loadOrMapHDT(Path hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException {
+		return loadOrMapHDT(hdtFileName.toAbsolutePath().toString(), listener, spec);
 	}
 
 	public static HDT loadOrMapHDT(String hdtFileName, ProgressListener listener, HDTOptions spec) throws IOException {

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/HDTImpl.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/HDTImpl.java
@@ -107,6 +107,13 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 		triples = TriplesFactory.createTriples(this.spec);
 	}
 
+	public HDTImpl(HeaderPrivate header, DictionaryPrivate dictionary, TriplesPrivate triples, HDTOptions spec) {
+		super(spec);
+		this.header = header;
+		this.dictionary = dictionary;
+		this.triples = triples;
+	}
+
 	@Override
 	public void loadFromHDT(InputStream input, ProgressListener listener) throws IOException {
 		ControlInfo ci = new ControlInformation();

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/FSDToMSDConverter.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/FSDToMSDConverter.java
@@ -1,0 +1,235 @@
+package com.the_qa_company.qendpoint.core.hdt.impl.converter;
+
+import com.the_qa_company.qendpoint.core.compact.integer.VByte;
+import com.the_qa_company.qendpoint.core.compact.sequence.DynamicSequence;
+import com.the_qa_company.qendpoint.core.compact.sequence.SequenceLog64BigDisk;
+import com.the_qa_company.qendpoint.core.dictionary.Dictionary;
+import com.the_qa_company.qendpoint.core.dictionary.DictionaryPrivate;
+import com.the_qa_company.qendpoint.core.dictionary.DictionarySectionPrivate;
+import com.the_qa_company.qendpoint.core.dictionary.impl.MultipleSectionDictionary;
+import com.the_qa_company.qendpoint.core.dictionary.impl.UnmodifiableDictionarySectionPrivate;
+import com.the_qa_company.qendpoint.core.dictionary.impl.section.WriteDictionarySection;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentRole;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.hdt.HDTVocabulary;
+import com.the_qa_company.qendpoint.core.hdt.Converter;
+import com.the_qa_company.qendpoint.core.hdt.impl.HDTBase;
+import com.the_qa_company.qendpoint.core.hdt.impl.HDTImpl;
+import com.the_qa_company.qendpoint.core.header.HeaderPrivate;
+import com.the_qa_company.qendpoint.core.header.PlainHeader;
+import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.triples.TripleID;
+import com.the_qa_company.qendpoint.core.triples.TriplesPrivate;
+import com.the_qa_company.qendpoint.core.triples.impl.OneReadTempTriples;
+import com.the_qa_company.qendpoint.core.triples.impl.WriteBitmapTriples;
+import com.the_qa_company.qendpoint.core.util.BitUtil;
+import com.the_qa_company.qendpoint.core.util.ContainerException;
+import com.the_qa_company.qendpoint.core.util.LiteralsUtils;
+import com.the_qa_company.qendpoint.core.util.io.CloseSuppressPath;
+import com.the_qa_company.qendpoint.core.util.io.Closer;
+import com.the_qa_company.qendpoint.core.util.io.IOUtil;
+import com.the_qa_company.qendpoint.core.util.string.ByteString;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class FSDToMSDConverter implements Converter {
+	private static final long[] BUCKET_LONG_CHECK = { 'H', 'D', 'T' };
+
+	@Override
+	public String getDestinationType() {
+		return HDTVocabulary.DICTIONARY_TYPE_MULT_SECTION;
+	}
+
+	@Override
+	public void convertHDTFile(HDT origin, Path destination, ProgressListener listener, HDTOptions options)
+			throws IOException {
+		// remove null
+		listener = ProgressListener.ofNullable(listener);
+		options = HDTOptions.ofNullable(options);
+
+		if (!(origin.getTriples() instanceof TriplesPrivate tp)) {
+			throw new IllegalArgumentException("Can't convert triples not implementing the TriplesPrivate interface");
+		}
+		TripleComponentOrder order = tp.getOrder();
+
+		if (order.getSubjectMapping() == null || order.getSubjectMapping() == TripleComponentRole.OBJECT) {
+			throw new IllegalArgumentException("Can't convert triples with order setting the objects in the subjects");
+		}
+
+		int bufferSize = options.getInt32(HDTOptionsKeys.LOADER_DISK_BUFFER_SIZE_KEY, CloseSuppressPath.BUFFER_SIZE);
+
+		if (!HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION.equals(origin.getDictionary().getType())) {
+			throw new IllegalArgumentException("Bad origin type! " + origin.getDictionary().getType());
+		}
+
+		Path wipDir = destination.resolveSibling(destination.getFileName() + ".tmp");
+		int i = 0;
+		// find an available name
+		while (Files.exists(wipDir)) {
+			wipDir = destination.resolveSibling(destination.getFileName() + "." + ++i + ".tmp");
+		}
+		try (CloseSuppressPath dir = CloseSuppressPath.of(wipDir)) {
+			dir.closeWithDeleteRecurse();
+			dir.mkdirs();
+
+			long nShared = origin.getDictionary().getNshared();
+			long nObjects = origin.getDictionary().getNobjects() - nShared;
+			try (SequenceLog64BigDisk objectMap = new SequenceLog64BigDisk(dir.resolve("objectMap"),
+					BitUtil.log2(nObjects), nObjects + 1)) {
+				try (FSDSectionBucketFiller buckets = new FSDSectionBucketFiller(options, dir.resolve("buckets"),
+						objectMap, bufferSize)) {
+					objectMap.clear();
+					// load the new objects
+					buckets.load(origin.getDictionary().getObjects().getSortedEntries(),
+							origin.getDictionary().getNobjects(), listener);
+
+					try (WriteBitmapTriples triples = new WriteBitmapTriples(options, dir.resolve("triples"),
+							bufferSize)) {
+						triples.load(new OneReadTempTriples(
+								new ObjectReSortIterator(new MapIterator<>(origin.getTriples().searchAll(), tid -> {
+									if (tid.getObject() <= nShared) {
+										return tid;
+									}
+									assert objectMap.get(tid.getObject() - nShared) != 0
+											: "bad index " + (tid.getObject() - nShared) + "/" + nShared;
+									return new TripleID(tid.getSubject(), tid.getPredicate(),
+											objectMap.get(tid.getObject() - nShared) + nShared);
+								}), order), order, origin.getTriples().getNumberOfElements()), listener);
+						// HEADER
+						HeaderPrivate header = new PlainHeader();
+
+						Dictionary od = origin.getDictionary();
+						// we don't need to copy the subjects/predicates/shared
+						// elements because only the object IDs are updated
+						DictionaryPrivate dictionary = new MultipleSectionDictionary(options,
+								UnmodifiableDictionarySectionPrivate.of(od.getSubjects()),
+								UnmodifiableDictionarySectionPrivate.of(od.getPredicates()), buckets.objects,
+								UnmodifiableDictionarySectionPrivate.of(od.getShared()));
+
+						HDTImpl hdt = new HDTImpl(header, dictionary, triples, options);
+						hdt.populateHeaderStructure(origin.getBaseURI());
+						long rawSize = HDTBase.getRawSize(origin.getHeader());
+						if (rawSize != -1) {
+							hdt.getHeader().insert("_:statistics", HDTVocabulary.ORIGINAL_SIZE, rawSize);
+						}
+						hdt.saveToHDT(destination, listener);
+						// no need to close the HDT, all the components are
+						// already closed after
+					}
+				}
+			}
+		}
+	}
+
+	static class FSDSectionBucketFiller implements Closeable {
+		private final TreeMap<ByteString, DictionarySectionPrivate> objects = new TreeMap<>();
+		private final DynamicSequence objectMap;
+		private final CloseSuppressPath dir;
+		private final HDTOptions options;
+		private final int bufferSize;
+
+		FSDSectionBucketFiller(HDTOptions options, CloseSuppressPath dir, DynamicSequence objectMap, int bufferSize)
+				throws IOException {
+			this.options = options;
+			this.dir = dir;
+			dir.mkdirs();
+			dir.closeWithDeleteRecurse();
+			this.objectMap = objectMap;
+			this.bufferSize = bufferSize;
+		}
+
+		public void load(Iterator<? extends CharSequence> iterator, long size, ProgressListener listener)
+				throws IOException {
+			Map<ByteString, Bucket> objectsAppender = new HashMap<>();
+			long objectIndex = 0;
+			try {
+				// loading triples
+				while (iterator.hasNext()) {
+					ByteString str = ByteString.of(iterator.next());
+					++objectIndex;
+					ByteString type = (ByteString) LiteralsUtils.getType(str);
+
+					try {
+						Bucket bucket = objectsAppender.computeIfAbsent(type, key -> {
+							int id = objects.size();
+							WriteDictionarySection section = new WriteDictionarySection(options,
+									dir.resolve("type_" + id + ".sec"), bufferSize);
+							objects.put(type, section);
+							try {
+								CloseSuppressPath idsPath = dir.resolve("type_" + id + ".triples");
+								return new Bucket(section.createAppender(size, listener), idsPath,
+										idsPath.openOutputStream(bufferSize));
+							} catch (IOException e) {
+								throw new ContainerException(e);
+							}
+						});
+						WriteDictionarySection.WriteDictionarySectionAppender appender = bucket.appender();
+						appender.append((ByteString) LiteralsUtils.removeType(str));
+						OutputStream ids = bucket.idWriter();
+						// write index -> inSectionIndex
+						VByte.encode(ids, objectIndex);
+					} catch (ContainerException e) {
+						throw (IOException) e.getCause();
+					}
+				}
+			} finally {
+				Closer.closeAll(objectsAppender.values());
+			}
+
+			long currentShift = 1;
+			for (ByteString type : objects.keySet()) {
+				Bucket bucket = objectsAppender.get(type);
+				assert bucket != null : "bucket not found for type " + type;
+				try (InputStream idsStream = bucket.idsPath().openInputStream(bufferSize)) {
+					long id;
+
+					while ((id = VByte.decode(idsStream)) != 0) {
+						assert objectMap.get(id) == 0 : "redefining object: " + id;
+						objectMap.set(id, currentShift++);
+					}
+					for (long l : BUCKET_LONG_CHECK) {
+						long r;
+						if ((r = VByte.decode(idsStream)) != l) {
+							throw new IOException("Check isn't the same as intended " + r + " != " + l);
+						}
+					}
+				}
+			}
+		}
+
+		@Override
+		public void close() throws IOException {
+			Closer.closeAll(objects);
+		}
+
+	}
+
+	private record Bucket(WriteDictionarySection.WriteDictionarySectionAppender appender, CloseSuppressPath idsPath,
+			OutputStream idWriter) implements Closeable {
+
+		@Override
+		public void close() throws IOException {
+			try {
+				VByte.encode(idWriter, 0);
+				for (long l : BUCKET_LONG_CHECK) {
+					VByte.encode(idWriter, l);
+				}
+			} finally {
+				IOUtil.closeAll(appender, idWriter);
+			}
+		}
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/MSDToFSDConverter.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/MSDToFSDConverter.java
@@ -1,0 +1,232 @@
+package com.the_qa_company.qendpoint.core.hdt.impl.converter;
+
+import com.the_qa_company.qendpoint.core.compact.sequence.DynamicSequence;
+import com.the_qa_company.qendpoint.core.compact.sequence.SequenceLog64BigDisk;
+import com.the_qa_company.qendpoint.core.dictionary.Dictionary;
+import com.the_qa_company.qendpoint.core.dictionary.DictionaryPrivate;
+import com.the_qa_company.qendpoint.core.dictionary.DictionarySection;
+import com.the_qa_company.qendpoint.core.dictionary.TempDictionarySection;
+import com.the_qa_company.qendpoint.core.dictionary.impl.FourSectionDictionary;
+import com.the_qa_company.qendpoint.core.dictionary.impl.UnmodifiableDictionarySectionPrivate;
+import com.the_qa_company.qendpoint.core.dictionary.impl.section.WriteDictionarySection;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentRole;
+import com.the_qa_company.qendpoint.core.exceptions.NotImplementedException;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.hdt.HDTVocabulary;
+import com.the_qa_company.qendpoint.core.hdt.Converter;
+import com.the_qa_company.qendpoint.core.hdt.impl.HDTBase;
+import com.the_qa_company.qendpoint.core.hdt.impl.HDTImpl;
+import com.the_qa_company.qendpoint.core.header.HeaderPrivate;
+import com.the_qa_company.qendpoint.core.header.PlainHeader;
+import com.the_qa_company.qendpoint.core.iterator.utils.ExceptionIterator;
+import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
+import com.the_qa_company.qendpoint.core.iterator.utils.MergeExceptionIterator;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.triples.IndexedNode;
+import com.the_qa_company.qendpoint.core.triples.TripleID;
+import com.the_qa_company.qendpoint.core.triples.TriplesPrivate;
+import com.the_qa_company.qendpoint.core.triples.impl.OneReadTempTriples;
+import com.the_qa_company.qendpoint.core.triples.impl.WriteBitmapTriples;
+import com.the_qa_company.qendpoint.core.util.BitUtil;
+import com.the_qa_company.qendpoint.core.util.LiteralsUtils;
+import com.the_qa_company.qendpoint.core.util.io.CloseSuppressPath;
+import com.the_qa_company.qendpoint.core.util.string.ByteString;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MSDToFSDConverter implements Converter {
+	@Override
+	public String getDestinationType() {
+		return HDTOptionsKeys.DICTIONARY_TYPE_VALUE_FOUR_SECTION;
+	}
+
+	@Override
+	public void convertHDTFile(HDT origin, Path destination, ProgressListener listener, HDTOptions options)
+			throws IOException {
+		// remove null
+		listener = ProgressListener.ofNullable(listener);
+		options = HDTOptions.ofNullable(options);
+
+		if (!(origin.getTriples() instanceof TriplesPrivate tp)) {
+			throw new IllegalArgumentException("Can't convert triples not implementing the TriplesPrivate interface");
+		}
+		TripleComponentOrder order = tp.getOrder();
+
+		if (order.getSubjectMapping() == null || order.getSubjectMapping() == TripleComponentRole.OBJECT) {
+			throw new IllegalArgumentException("Can't convert triples with order setting the objects in the subjects");
+		}
+
+		int bufferSize = options.getInt32(HDTOptionsKeys.LOADER_DISK_BUFFER_SIZE_KEY, CloseSuppressPath.BUFFER_SIZE);
+
+		if (!HDTVocabulary.DICTIONARY_TYPE_MULT_SECTION.equals(origin.getDictionary().getType())) {
+			throw new IllegalArgumentException("Bad origin type! " + origin.getDictionary().getType());
+		}
+
+		Path wipDir = destination.resolveSibling(destination.getFileName() + ".tmp");
+		int i = 0;
+		// find an available name
+		while (Files.exists(wipDir)) {
+			wipDir = destination.resolveSibling(destination.getFileName() + "." + ++i + ".tmp");
+		}
+		try (CloseSuppressPath dir = CloseSuppressPath.of(wipDir)) {
+			dir.closeWithDeleteRecurse();
+			dir.mkdirs();
+
+			long nObjects = origin.getDictionary().getNAllObjects();
+			long nShared = origin.getDictionary().getNshared();
+			try (SequenceLog64BigDisk objectMap = new SequenceLog64BigDisk(dir.resolve("objectMap"),
+					BitUtil.log2(nObjects), nObjects + 1)) {
+				Map<? extends CharSequence, DictionarySection> objects = origin.getDictionary().getAllObjects();
+				MSDSectionMerger merger = new MSDSectionMerger(objects, objectMap);
+				objectMap.clear();
+				try (WriteDictionarySection wObjects = new WriteDictionarySection(options,
+						dir.resolveSibling("objects"), bufferSize)) {
+					// load the new objects
+					wObjects.load(merger, listener);
+
+					try (WriteBitmapTriples triples = new WriteBitmapTriples(options, dir.resolve("triples"),
+							bufferSize)) {
+						triples.load(new OneReadTempTriples(
+								new ObjectReSortIterator(new MapIterator<>(origin.getTriples().searchAll(), tid -> {
+									if (tid.getObject() <= nShared) {
+										return tid;
+									}
+									assert objectMap.get(tid.getObject() - nShared) != 0
+											: "bad index " + (tid.getObject() - nShared) + "/" + nShared;
+									return new TripleID(tid.getSubject(), tid.getPredicate(),
+											objectMap.get(tid.getObject() - nShared) + nShared);
+								}), order), order, origin.getTriples().getNumberOfElements()), listener);
+						// HEADER
+						HeaderPrivate header = new PlainHeader();
+
+						Dictionary od = origin.getDictionary();
+						// we don't need to copy the subjects/predcates/shared
+						// elements because only the object IDs are updated
+						DictionaryPrivate dictionary = new FourSectionDictionary(options,
+								UnmodifiableDictionarySectionPrivate.of(od.getSubjects()),
+								UnmodifiableDictionarySectionPrivate.of(od.getPredicates()), wObjects,
+								UnmodifiableDictionarySectionPrivate.of(od.getShared()));
+
+						HDTImpl hdt = new HDTImpl(header, dictionary, triples, options);
+						hdt.populateHeaderStructure(origin.getBaseURI());
+						long rawSize = HDTBase.getRawSize(origin.getHeader());
+						if (rawSize != -1) {
+							hdt.getHeader().insert("_:statistics", HDTVocabulary.ORIGINAL_SIZE, rawSize);
+						}
+						hdt.saveToHDT(destination, listener);
+						// no need to close the HDT, all the components are
+						// already closed after
+					}
+				}
+			}
+		}
+	}
+
+	static class MSDSectionMerger implements TempDictionarySection {
+		private final Map<? extends CharSequence, DictionarySection> objects;
+		private final DynamicSequence objectMap;
+
+		MSDSectionMerger(Map<? extends CharSequence, DictionarySection> objects, DynamicSequence objectMap) {
+			this.objects = objects;
+			this.objectMap = objectMap;
+		}
+
+		@Override
+		public long locate(CharSequence s) {
+			throw new NotImplementedException();
+		}
+
+		@Override
+		public CharSequence extract(long pos) {
+			throw new NotImplementedException();
+		}
+
+		@Override
+		public long size() {
+			return objects.values().stream().mapToLong(DictionarySection::size).sum();
+		}
+
+		@Override
+		public long getNumberOfElements() {
+			return objects.values().stream().mapToLong(DictionarySection::getNumberOfElements).sum();
+		}
+
+		@Override
+		public Iterator<? extends CharSequence> getSortedEntries() {
+			Set<? extends Map.Entry<? extends CharSequence, DictionarySection>> set = objects.entrySet();
+			List<ExceptionIterator<IndexedNode, RuntimeException>> iterators = new ArrayList<>(set.size());
+			long shift = 1;
+			for (Map.Entry<? extends CharSequence, DictionarySection> e : set) {
+
+				ByteString type = ByteString.of(e.getKey());
+				DictionarySection section = e.getValue();
+
+				final long currentShift = shift;
+				ExceptionIterator<? extends CharSequence, RuntimeException> it = ExceptionIterator
+						.of(section.getSortedEntries());
+				if (LiteralsUtils.NO_DATATYPE.equals(type) || LiteralsUtils.LITERAL_LANG_TYPE.equals(type)) {
+					// no datatype, we don't need to add anything
+					iterators.add(it.map((s, index) -> new IndexedNode(ByteString.of(s), index + currentShift)));
+				} else {
+					final ByteString operType = type.copyPreAppend("^^");
+					iterators.add(
+							it.map((s, index) -> new IndexedNode(operType.copyPreAppend(s), index + currentShift)));
+				}
+				shift += section.getNumberOfElements();
+			}
+
+			ExceptionIterator<IndexedNode, RuntimeException> merge = MergeExceptionIterator.buildOfTree(iterators,
+					IndexedNode::compareTo);
+			return merge.map((in, futureIndex) -> {
+				assert objectMap.get(in.getIndex()) == 0 : "id " + in.getIndex();
+				objectMap.set(in.getIndex(), futureIndex + 1);
+				return in.getNode();
+			}).asIterator();
+		}
+
+		@Override
+		public void close() {
+			// closed by the HDT owner, nothing to do
+		}
+
+		@Override
+		public long add(CharSequence str) {
+			throw new NotImplementedException();
+		}
+
+		@Override
+		public void remove(CharSequence str) {
+			throw new NotImplementedException();
+		}
+
+		@Override
+		public void sort() {
+			// already sorted
+		}
+
+		@Override
+		public void clear() {
+			throw new NotImplementedException();
+		}
+
+		@Override
+		public boolean isSorted() {
+			return true;
+		}
+
+		@Override
+		public Iterator<? extends CharSequence> getEntries() {
+			return getSortedEntries();
+		}
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/ObjectReSortIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/ObjectReSortIterator.java
@@ -1,0 +1,65 @@
+package com.the_qa_company.qendpoint.core.hdt.impl.converter;
+
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+import com.the_qa_company.qendpoint.core.iterator.utils.EmptyIterator;
+import com.the_qa_company.qendpoint.core.iterator.utils.FetcherIterator;
+import com.the_qa_company.qendpoint.core.iterator.utils.PeekIterator;
+import com.the_qa_company.qendpoint.core.triples.TripleID;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Simple version of
+ * {@link com.the_qa_company.qendpoint.core.dictionary.impl.kcat.GroupBySubjectMapIterator}
+ * with only the sort by the object.
+ */
+public class ObjectReSortIterator extends FetcherIterator<TripleID> {
+	private final Comparator<TripleID> tripleIDComparator;
+	private final PeekIterator<TripleID> ids;
+	private Iterator<TripleID> next = EmptyIterator.of();
+
+	public ObjectReSortIterator(Iterator<TripleID> ids, TripleComponentOrder order) {
+		this.ids = new PeekIterator<>(ids);
+		switch (order) {
+		case SPO, PSO -> tripleIDComparator = Comparator.comparingLong(TripleID::getObject);
+		case SOP, POS -> tripleIDComparator = Comparator.comparingLong(TripleID::getPredicate)
+				.thenComparingLong(TripleID::getObject);
+		default -> // OSP, OPS, Unknown
+			// ngl, I'm not even sure it will work for triple order != SPO
+			throw new IllegalArgumentException("Can't resort triple component of type: " + order);
+		}
+	}
+
+	@Override
+	protected TripleID getNext() {
+		if (next.hasNext()) {
+			return next.next();
+		}
+
+		if (!ids.hasNext()) {
+			return null;
+		}
+
+		List<TripleID> next = new ArrayList<>();
+		TripleID id = ids.next().clone();
+		next.add(id);
+
+		long s = id.getSubject();
+		long p = id.getPredicate();
+
+		while (ids.hasNext()) {
+			TripleID nextTriple = ids.peek();
+			if (!(nextTriple.getSubject() == s && nextTriple.getPredicate() == p)) {
+				break;
+			}
+			next.add(ids.next().clone());
+		}
+		// we don't need to compare other components because the (s,p) are equal
+		next.sort(tripleIDComparator);
+		this.next = next.iterator();
+		return this.next.next();
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/utils/EmptyIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/utils/EmptyIterator.java
@@ -1,0 +1,20 @@
+package com.the_qa_company.qendpoint.core.iterator.utils;
+
+import java.util.Iterator;
+
+public class EmptyIterator<T> implements Iterator<T> {
+	public static <T> Iterator<T> of() {
+		return new EmptyIterator<>();
+	}
+
+	@Override
+	public boolean hasNext() {
+		return false;
+	}
+
+	@Override
+	public T next() {
+		return null;
+	}
+
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/utils/MergeExceptionIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/utils/MergeExceptionIterator.java
@@ -106,6 +106,20 @@ public class MergeExceptionIterator<T, E extends Exception> implements Exception
 	/**
 	 * Create a tree of merge iterators from an array of element
 	 *
+	 * @param array      the elements
+	 * @param comparator comparator for the merge iterator
+	 * @param <T>        type of the element
+	 * @param <E>        exception returned by the iterator
+	 * @return the iterator
+	 */
+	public static <T, E extends Exception> ExceptionIterator<T, E> buildOfTree(List<ExceptionIterator<T, E>> array,
+			Comparator<T> comparator) {
+		return buildOfTree(Function.identity(), comparator, array, 0, array.size());
+	}
+
+	/**
+	 * Create a tree of merge iterators from an array of element
+	 *
 	 * @param itFunction a function to create an iterator from an element
 	 * @param comp       comparator for the merge iterator
 	 * @param array      the elements

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptions.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptions.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.DoubleSupplier;
+import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -327,6 +328,42 @@ public interface HDTOptions {
 	 */
 	default long getInt(String key, long defaultValue) {
 		return getInt(key, () -> defaultValue);
+	}
+
+	/**
+	 * get a long value
+	 *
+	 * @param key key
+	 * @return value or 0 if not defined
+	 */
+	default int getInt32(String key) {
+		return getInt32(key, 0);
+	}
+
+	/**
+	 * get a long
+	 *
+	 * @param key          key
+	 * @param defaultValue default value
+	 * @return long or defaultValue if the value isn't defined
+	 */
+	default int getInt32(String key, IntSupplier defaultValue) {
+		String l = get(key);
+		if (l == null) {
+			return defaultValue.getAsInt();
+		}
+		return Integer.parseInt(l);
+	}
+
+	/**
+	 * get a long
+	 *
+	 * @param key          key
+	 * @param defaultValue default value
+	 * @return long or defaultValue if the value isn't defined
+	 */
+	default int getInt32(String key, int defaultValue) {
+		return getInt32(key, () -> defaultValue);
 	}
 
 	/**

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptionsKeys.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptionsKeys.java
@@ -321,7 +321,7 @@ public class HDTOptionsKeys {
 	/**
 	 * 4 Section dictionary
 	 */
-	@Value(key = DICTIONARY_TYPE_KEY, desc = "Four sectiob dictionary")
+	@Value(key = DICTIONARY_TYPE_KEY, desc = "Four section dictionary")
 	public static final String DICTIONARY_TYPE_VALUE_FOUR_SECTION = HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION;
 	/**
 	 * Prefix AND Suffix front-coded (PSFC) 4 Section dictionary

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/tools/HDTConvertTool.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/tools/HDTConvertTool.java
@@ -1,0 +1,128 @@
+package com.the_qa_company.qendpoint.core.tools;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.internal.Lists;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.hdt.HDTManager;
+import com.the_qa_company.qendpoint.core.hdt.HDTVersion;
+import com.the_qa_company.qendpoint.core.hdt.Converter;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.util.StopWatch;
+import com.the_qa_company.qendpoint.core.util.listener.ColorTool;
+import com.the_qa_company.qendpoint.core.util.listener.MultiThreadListenerConsole;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class HDTConvertTool {
+
+	private ColorTool colorTool;
+
+	@Parameter(description = "<input HDT> <output HDT> <newType>")
+	public List<String> parameters = Lists.newArrayList();
+
+	@Parameter(names = "-options", description = "HDT Conversion options (override those of config file)")
+	public String options;
+
+	@Parameter(names = "-config", description = "Conversion config file")
+	public String configFile;
+	@Parameter(names = "-load", description = "load the inputHDT into memory")
+	public boolean loadHDT;
+	@Parameter(names = "-version", description = "Prints the HDT version number")
+	public boolean showVersion;
+	@Parameter(names = "-dict", description = "Prints the HDT dictionaries")
+	public boolean showDictionaries;
+
+	@Parameter(names = "-quiet", description = "Do not show progress of the conversion")
+	public boolean quiet;
+
+	@Parameter(names = "-color", description = "Print using color (if available)")
+	public boolean color;
+
+	private HDT input(Path hdt, HDTOptions spec, ProgressListener listener) throws IOException {
+		if (loadHDT) {
+			return HDTManager.loadHDT(hdt, listener, spec);
+		} else {
+			return HDTManager.mapHDT(hdt, listener, spec);
+		}
+	}
+
+	public void execute() throws IOException {
+		HDTOptions spec;
+		if (configFile != null) {
+			spec = HDTOptions.readFromFile(configFile);
+		} else {
+			spec = HDTOptions.of();
+		}
+		if (options != null) {
+			spec.setOptions(options);
+		}
+
+		Path input = Path.of(parameters.get(0));
+		Path output = Path.of(parameters.get(1));
+		String newType = parameters.get(2);
+
+		if (input.toAbsolutePath().equals(output.toAbsolutePath())) {
+			colorTool.error("Input = Output!");
+			return;
+		}
+
+		ProgressListener listenerConsole;
+		if (!quiet) {
+			MultiThreadListenerConsole mtlc = new MultiThreadListenerConsole(color);
+			colorTool.setConsole(mtlc);
+			listenerConsole = mtlc;
+		} else {
+			listenerConsole = ProgressListener.ignore();
+		}
+
+		try (HDT hdt = input(input, spec, listenerConsole)) {
+			String oldType = hdt.getDictionary().getType();
+
+			colorTool.log("find hdt of type: " + oldType);
+			Converter converter;
+			try {
+				converter = Converter.newConverter(hdt, newType);
+			} catch (IllegalArgumentException e) {
+				colorTool.error(e.getMessage());
+				return;
+			}
+			StopWatch watch = new StopWatch();
+			converter.convertHDTFile(hdt, output, listenerConsole, spec);
+			watch.stop();
+
+			colorTool.log("Converted HDT to " + newType + " in " + watch + ".");
+		}
+	}
+
+	public static void main(String[] args) throws Throwable {
+		HDTConvertTool hdtconvert = new HDTConvertTool();
+		JCommander com = new JCommander(hdtconvert);
+		com.parse(args);
+		com.setProgramName("hdtconvert");
+		hdtconvert.colorTool = new ColorTool(hdtconvert.color, hdtconvert.quiet);
+
+		if (hdtconvert.showVersion) {
+			hdtconvert.colorTool.log(HDTVersion.get_version_string("."));
+			return;
+		} else if (hdtconvert.showDictionaries) {
+			HDTOptionsKeys.Option dict = HDTOptionsKeys.getOptionMap().get(HDTOptionsKeys.DICTIONARY_TYPE_KEY);
+			List<HDTOptionsKeys.OptionValue> values = dict.getValues();
+			hdtconvert.colorTool.log("Known dictionaries:");
+			for (HDTOptionsKeys.OptionValue value : values) {
+				hdtconvert.colorTool.log(hdtconvert.colorTool.color(5, 1, 0) + "`" + value.getValue() + "`"
+						+ hdtconvert.colorTool.colorReset() + ": " + value.getValueInfo().desc());
+			}
+			return;
+		} else if (hdtconvert.parameters.size() < 3) {
+			com.usage();
+			System.exit(1);
+		}
+
+		hdtconvert.execute();
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/io/CloseOnceInputStream.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/io/CloseOnceInputStream.java
@@ -1,0 +1,88 @@
+package com.the_qa_company.qendpoint.core.util.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class CloseOnceInputStream extends InputStream {
+	private final InputStream stream;
+	private boolean closed;
+
+	public CloseOnceInputStream(InputStream stream) {
+		this.stream = stream;
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (!closed) {
+			stream.close();
+			closed = true;
+		}
+		super.close();
+	}
+
+	@Override
+	public int read() throws IOException {
+		return stream.read();
+	}
+
+	@Override
+	public int read(byte[] b) throws IOException {
+		return stream.read(b);
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		return stream.read(b, off, len);
+	}
+
+	@Override
+	public byte[] readAllBytes() throws IOException {
+		return stream.readAllBytes();
+	}
+
+	@Override
+	public byte[] readNBytes(int len) throws IOException {
+		return stream.readNBytes(len);
+	}
+
+	@Override
+	public int readNBytes(byte[] b, int off, int len) throws IOException {
+		return stream.readNBytes(b, off, len);
+	}
+
+	@Override
+	public long skip(long n) throws IOException {
+		return stream.skip(n);
+	}
+
+	@Override
+	public void skipNBytes(long n) throws IOException {
+		stream.skipNBytes(n);
+	}
+
+	@Override
+	public int available() throws IOException {
+		return stream.available();
+	}
+
+	@Override
+	public void mark(int readlimit) {
+		stream.mark(readlimit);
+	}
+
+	@Override
+	public void reset() throws IOException {
+		stream.reset();
+	}
+
+	@Override
+	public boolean markSupported() {
+		return stream.markSupported();
+	}
+
+	@Override
+	public long transferTo(OutputStream out) throws IOException {
+		return stream.transferTo(out);
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/io/CloseOnceOutputStream.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/io/CloseOnceOutputStream.java
@@ -1,0 +1,41 @@
+package com.the_qa_company.qendpoint.core.util.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class CloseOnceOutputStream extends OutputStream {
+	@Override
+	public void write(int b) throws IOException {
+		stream.write(b);
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		stream.write(b);
+	}
+
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		stream.write(b, off, len);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		stream.flush();
+	}
+
+	private final OutputStream stream;
+	private boolean closed;
+
+	public CloseOnceOutputStream(OutputStream stream) {
+		this.stream = stream;
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (!closed) {
+			stream.close();
+			closed = true;
+		}
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/string/ByteString.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/string/ByteString.java
@@ -77,6 +77,26 @@ public interface ByteString extends CharSequence, Comparable<ByteString> {
 	}
 
 	/**
+	 * copy this string and append another string
+	 *
+	 * @param other other string
+	 * @return new byte string
+	 */
+	default ByteString copyPreAppend(CharSequence other) {
+		return ByteString.of(other).copyAppend(this);
+	}
+
+	/**
+	 * copy this string and append another string
+	 *
+	 * @param other other string
+	 * @return new byte string
+	 */
+	default ByteString copyPreAppend(ByteString other) {
+		return other.copyAppend(this);
+	}
+
+	/**
 	 * @return copy this byte string into another one
 	 */
 	default ByteString copy() {

--- a/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/dictionary/impl/section/WriteDictionarySectionTest.java
+++ b/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/dictionary/impl/section/WriteDictionarySectionTest.java
@@ -1,0 +1,69 @@
+package com.the_qa_company.qendpoint.core.dictionary.impl.section;
+
+import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.util.LargeFakeDataSetStreamSupplier;
+import com.the_qa_company.qendpoint.core.util.string.ByteString;
+import org.apache.commons.io.file.PathUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+public class WriteDictionarySectionTest {
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	private LargeFakeDataSetStreamSupplier stream() {
+		return LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(10_000, 75).withUnicode(true)
+				.withMaxLiteralSize(20).withMaxElementSplit(50);
+	}
+
+	@Test
+	public void appenderTest() throws IOException {
+		Path dir = tempDir.getRoot().toPath();
+		try {
+
+			try (WriteDictionarySection section1 = new WriteDictionarySection(HDTOptions.of(), dir.resolve("t1"), 4096);
+					WriteDictionarySection section2 = new WriteDictionarySection(HDTOptions.of(), dir.resolve("t2"),
+							4096)) {
+				Iterator<? extends CharSequence> it1 = stream().objectIterator();
+				Iterator<? extends CharSequence> it2 = stream().objectIterator();
+
+				section1.load(new MapIterator<>(it1, ByteString::of), 10_000, ProgressListener.ignore());
+
+				try (WriteDictionarySection.WriteDictionarySectionAppender appender = section2.createAppender(10_000,
+						ProgressListener.ignore())) {
+					while (it2.hasNext()) {
+						CharSequence next = it2.next();
+						appender.append(ByteString.of(next));
+					}
+				}
+				Path t1Save = dir.resolve("t1.save");
+				Path t2Save = dir.resolve("t2.save");
+				try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(t1Save))) {
+					section1.save(os, ProgressListener.ignore());
+				}
+				try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(t2Save))) {
+					section2.save(os, ProgressListener.ignore());
+				}
+
+				byte[] t1Bytes = Files.readAllBytes(t1Save);
+				byte[] t2Bytes = Files.readAllBytes(t2Save);
+
+				Assert.assertArrayEquals(t1Bytes, t2Bytes);
+
+			}
+		} finally {
+			PathUtils.deleteDirectory(dir);
+		}
+	}
+}

--- a/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/ConverterTest.java
+++ b/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/hdt/impl/converter/ConverterTest.java
@@ -1,0 +1,94 @@
+package com.the_qa_company.qendpoint.core.hdt.impl.converter;
+
+import com.the_qa_company.qendpoint.core.exceptions.NotFoundException;
+import com.the_qa_company.qendpoint.core.exceptions.ParserException;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.hdt.HDTManager;
+import com.the_qa_company.qendpoint.core.hdt.HDTManagerTest;
+import com.the_qa_company.qendpoint.core.hdt.Converter;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.util.LargeFakeDataSetStreamSupplier;
+import com.the_qa_company.qendpoint.core.util.io.AbstractMapMemoryTest;
+import org.apache.commons.io.file.PathUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ConverterTest extends AbstractMapMemoryTest {
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	private LargeFakeDataSetStreamSupplier stream() {
+		return LargeFakeDataSetStreamSupplier.createSupplierWithMaxTriples(10_000, 75).withMaxElementSplit(50)
+				.withMaxLiteralSize(20).withUnicode(true);
+	}
+
+	@Test
+	public void fsdToMsdTest() throws IOException, ParserException, NotFoundException {
+		Path root = tempDir.newFolder().toPath();
+		try {
+			Path hdtfsdPath = root.resolve("hdtfsd.hdt");
+			Path hdtmsdPath = root.resolve("hdtmsd.hdt");
+
+			stream().createAndSaveFakeHDT(HDTOptions.of(HDTOptionsKeys.DICTIONARY_TYPE_KEY,
+					HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS, HDTOptionsKeys.LOADER_TYPE_KEY,
+					HDTOptionsKeys.LOADER_TYPE_VALUE_DISK, HDTOptionsKeys.LOADER_DISK_LOCATION_KEY,
+					root.resolve("gen")), hdtmsdPath);
+
+			stream().createAndSaveFakeHDT(
+					HDTOptions.of(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_FOUR_SECTION,
+							HDTOptionsKeys.LOADER_TYPE_KEY, HDTOptionsKeys.LOADER_TYPE_VALUE_DISK,
+							HDTOptionsKeys.LOADER_DISK_LOCATION_KEY, root.resolve("gen")),
+					hdtfsdPath);
+
+			try (HDT fsd = HDTManager.mapHDT(hdtfsdPath); HDT msd = HDTManager.mapHDT(hdtmsdPath)) {
+				Converter converter = Converter.newConverter(msd, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_FOUR_SECTION);
+				Path mutPath = root.resolve("mut.hdt");
+				converter.convertHDTFile(msd, mutPath, ProgressListener.ignore(), HDTOptions.of());
+
+				try (HDT mut = HDTManager.mapHDT(mutPath)) {
+					HDTManagerTest.HDTManagerTestBase.assertEqualsHDT(fsd, mut);
+				}
+			}
+		} finally {
+			PathUtils.deleteDirectory(root);
+		}
+	}
+
+	@Test
+	public void msdToFsdTest() throws IOException, ParserException, NotFoundException {
+		Path root = tempDir.newFolder().toPath();
+		try {
+			Path hdtfsdPath = root.resolve("hdtfsd.hdt");
+			Path hdtmsdPath = root.resolve("hdtmsd.hdt");
+
+			stream().createAndSaveFakeHDT(HDTOptions.of(HDTOptionsKeys.DICTIONARY_TYPE_KEY,
+					HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS, HDTOptionsKeys.LOADER_TYPE_KEY,
+					HDTOptionsKeys.LOADER_TYPE_VALUE_DISK, HDTOptionsKeys.LOADER_DISK_LOCATION_KEY,
+					root.resolve("gen")), hdtmsdPath);
+
+			stream().createAndSaveFakeHDT(
+					HDTOptions.of(HDTOptionsKeys.DICTIONARY_TYPE_KEY, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_FOUR_SECTION,
+							HDTOptionsKeys.LOADER_TYPE_KEY, HDTOptionsKeys.LOADER_TYPE_VALUE_DISK,
+							HDTOptionsKeys.LOADER_DISK_LOCATION_KEY, root.resolve("gen")),
+					hdtfsdPath);
+
+			try (HDT fsd = HDTManager.mapHDT(hdtfsdPath); HDT msd = HDTManager.mapHDT(hdtmsdPath)) {
+				Converter converter = Converter.newConverter(fsd, HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS);
+				Path mutPath = root.resolve("mut.hdt");
+				converter.convertHDTFile(fsd, mutPath, ProgressListener.ignore(), HDTOptions.of());
+
+				try (HDT mut = HDTManager.mapHDT(mutPath)) {
+					HDTManagerTest.HDTManagerTestBase.assertEqualsHDT(msd, mut);
+				}
+			}
+		} finally {
+			PathUtils.deleteDirectory(root);
+		}
+	}
+}

--- a/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/util/LargeFakeDataSetStreamSupplier.java
+++ b/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/util/LargeFakeDataSetStreamSupplier.java
@@ -1,18 +1,17 @@
 package com.the_qa_company.qendpoint.core.util;
 
 import com.the_qa_company.qendpoint.core.enums.CompressionType;
-import com.the_qa_company.qendpoint.core.enums.RDFNotation;
 import com.the_qa_company.qendpoint.core.exceptions.NotImplementedException;
 import com.the_qa_company.qendpoint.core.exceptions.ParserException;
 import com.the_qa_company.qendpoint.core.hdt.HDT;
 import com.the_qa_company.qendpoint.core.hdt.HDTManager;
+import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
 import com.the_qa_company.qendpoint.core.options.HDTOptions;
-import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
 import com.the_qa_company.qendpoint.core.triples.TripleString;
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
-import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 import com.the_qa_company.qendpoint.core.util.concurrent.ExceptionThread;
 import com.the_qa_company.qendpoint.core.util.string.ByteStringUtil;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -259,6 +258,18 @@ public class LargeFakeDataSetStreamSupplier {
 	 * @throws ParserException parsing exception
 	 * @throws IOException     io exception
 	 */
+	public void createAndSaveFakeHDT(HDTOptions spec, Path location) throws ParserException, IOException {
+		createAndSaveFakeHDT(spec, location.toAbsolutePath().toString());
+	}
+
+	/**
+	 * create an HDT from the stream and save it to a file
+	 *
+	 * @param spec     hdt options
+	 * @param location save location
+	 * @throws ParserException parsing exception
+	 * @throws IOException     io exception
+	 */
 	public void createAndSaveFakeHDT(HDTOptions spec, String location) throws ParserException, IOException {
 		try (HDT hdt = createFakeHDT(spec)) {
 			hdt.saveToHDT(location, null);
@@ -303,6 +314,13 @@ public class LargeFakeDataSetStreamSupplier {
 			// no type/language node
 			return text;
 		}
+	}
+
+	/**
+	 * @return the stream of the objects
+	 */
+	public Iterator<? extends CharSequence> objectIterator() {
+		return new MapIterator<>(createTripleStringStream(), TripleString::getObject);
 	}
 
 	private class FakeStatementIterator implements Iterator<TripleString> {


### PR DESCRIPTION
Issue resolved (if any): #270

Description of this pull request:

Add converter to convert HDT dictionary, it also add a hdtConvert script, usage:

```powershell
hdtConvert.ps1 <input hdt> <output hdt> <output dictionary type>
```

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
