### PR TITLE
GH-279 optimizer disabler and query config

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: ${{ github.event.before }}
+          base: ${{ github.event.base_ref }}
           filters: |
             core:
               - 'qendpoint-core/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: ${{ github.event.before }}
+          base: ${{ github.event.base_ref }}
           filters: |
             core:
               - 'qendpoint-core/**'

--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/compiler/ConfigSailConnection.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/compiler/ConfigSailConnection.java
@@ -1,0 +1,41 @@
+package com.the_qa_company.qendpoint.compiler;
+
+/**
+ * Interface to implement into a {@link org.eclipse.rdf4j.sail.SailConnection}
+ * returned by the source of a {@link CompiledSail}, the configs will be added
+ * using comments
+ *
+ * @author Antoine Willerval
+ */
+public interface ConfigSailConnection {
+	/**
+	 * set a config without any value
+	 *
+	 * @param cfg the config
+	 */
+	void setConfig(String cfg);
+
+	/**
+	 * set a config with a value
+	 *
+	 * @param cfg   the config
+	 * @param value the config value
+	 */
+	void setConfig(String cfg, String value);
+
+	/**
+	 * test if the connection has a config
+	 *
+	 * @param cfg the config
+	 * @return true if the config was set
+	 */
+	boolean hasConfig(String cfg);
+
+	/**
+	 * get a config value
+	 *
+	 * @param cfg the config
+	 * @return the config value or null if unset
+	 */
+	String getConfig(String cfg);
+}

--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/store/EndpointStore.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/store/EndpointStore.java
@@ -62,6 +62,10 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class EndpointStore extends AbstractNotifyingSail implements FederatedServiceResolverClient {
+	/**
+	 * disable the optimizer
+	 */
+	public static final String QUERY_CONFIG_NO_OPTIMIZER = "no_optimizer";
 	private static final AtomicLong ENDPOINT_DEBUG_ID_GEN = new AtomicLong();
 	private static final Logger logger = LoggerFactory.getLogger(EndpointStore.class);
 	private final long debugId;

--- a/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreConnection.java
+++ b/hdt-qs-backend/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreConnection.java
@@ -1,5 +1,6 @@
 package com.the_qa_company.qendpoint.store;
 
+import com.the_qa_company.qendpoint.compiler.ConfigSailConnection;
 import com.the_qa_company.qendpoint.store.exception.EndpointTimeoutException;
 import org.eclipse.rdf4j.common.concurrent.locks.Lock;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -31,12 +32,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class EndpointStoreConnection extends SailSourceConnection {
+public class EndpointStoreConnection extends SailSourceConnection implements ConfigSailConnection {
 	private static final Timer TIMEOUT_TIMER = new Timer("EndpointStoreConnectionTimer", true);
 	static long debugWaittime = 0L;
 	private static final AtomicLong DEBUG_ID_STORE = new AtomicLong();
@@ -54,6 +57,7 @@ public class EndpointStoreConnection extends SailSourceConnection {
 	private Lock updateLock;
 	private CloseTask closeTask;
 	private final AtomicBoolean timeout = new AtomicBoolean();
+	private final Map<String, String> config = new HashMap<>();
 
 	public EndpointStoreConnection(EndpointStore endpoint) throws InterruptedException {
 		super(endpoint, endpoint.getCurrentSaliStore(), new StrictEvaluationStrategyFactory());
@@ -109,7 +113,7 @@ public class EndpointStoreConnection extends SailSourceConnection {
 		// each endpointStoreConnection has a triple source ( ideally it should
 		// be in the query preparer as in rdf4j..)
 		this.tripleSource = new EndpointTripleSource(this, endpoint);
-		this.queryPreparer = new EndpointStoreQueryPreparer(endpoint, tripleSource);
+		this.queryPreparer = new EndpointStoreQueryPreparer(endpoint, tripleSource, this);
 	}
 
 	@Override
@@ -189,6 +193,26 @@ public class EndpointStoreConnection extends SailSourceConnection {
 		// super.setNamespaceInternal(prefix,name);
 		this.getCurrentConnectionWrite().setNamespace(prefix, name);
 		// this.getCurrentConnectionRead().setNamespace(prefix, name);
+	}
+
+	@Override
+	public void setConfig(String cfg) {
+		config.put(cfg, "");
+	}
+
+	@Override
+	public void setConfig(String cfg, String value) {
+		config.put(cfg, value);
+	}
+
+	@Override
+	public boolean hasConfig(String cfg) {
+		return config.containsKey(cfg);
+	}
+
+	@Override
+	public String getConfig(String cfg) {
+		return config.get(cfg);
 	}
 
 	@Override

--- a/hdt-qs-backend/src/test/java/com/the_qa_company/qendpoint/compiler/ConfigSailConnectionTest.java
+++ b/hdt-qs-backend/src/test/java/com/the_qa_company/qendpoint/compiler/ConfigSailConnectionTest.java
@@ -1,0 +1,93 @@
+package com.the_qa_company.qendpoint.compiler;
+
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.NotifyingSail;
+import org.eclipse.rdf4j.sail.NotifyingSailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.helpers.NotifyingSailConnectionWrapper;
+import org.eclipse.rdf4j.sail.helpers.NotifyingSailWrapper;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConfigSailConnectionTest {
+	@Test
+	public void test() throws IOException {
+		TestSail testSail = new TestSail(new MemoryStore());
+		SparqlRepository repo = CompiledSail.compiler().withSourceSail(testSail).compileToSparqlRepository();
+		try {
+			repo.init();
+
+			try (SailRepositoryConnection rpc = repo.getConnection()) {
+				if (!(rpc.getSailConnection() instanceof CompiledSail.CompiledSailConnection csc)) {
+					fail("repo connection should be a CompiledSailConnection, but is "
+							+ rpc.getSailConnection().getClass());
+					return;
+				}
+				if (!(csc.getSourceConnection() instanceof ConfigSailConnection configConn)) {
+					fail("source connection should be a ConfigSailConnection, but is "
+							+ csc.getSourceConnection().getClass());
+					return;
+				}
+
+				repo.executeTupleQuery(rpc, """
+						#cfg_value:value_v
+						#cfg_no_value
+						SELECT * {?s ?p ?o}
+						""", 0).close();
+
+				assertTrue(configConn.hasConfig("cfg_no_value"));
+				assertEquals(configConn.getConfig("cfg_value"), "value_v");
+			}
+		} finally {
+			repo.shutDown();
+		}
+	}
+
+	private static class TestSail extends NotifyingSailWrapper {
+		public TestSail(NotifyingSail baseSail) {
+			super(baseSail);
+		}
+
+		@Override
+		public NotifyingSailConnection getConnection() throws SailException {
+			return new TestSailConnection(super.getConnection());
+		}
+	}
+
+	private static class TestSailConnection extends NotifyingSailConnectionWrapper implements ConfigSailConnection {
+
+		private final Map<String, String> config = new HashMap<>();
+
+		public TestSailConnection(NotifyingSailConnection baseSail) {
+			super(baseSail);
+		}
+
+		@Override
+		public void setConfig(String cfg) {
+			config.put(cfg, "");
+		}
+
+		@Override
+		public void setConfig(String cfg, String value) {
+			config.put(cfg, value);
+		}
+
+		@Override
+		public boolean hasConfig(String cfg) {
+			return config.containsKey(cfg);
+		}
+
+		@Override
+		public String getConfig(String cfg) {
+			return config.get(cfg);
+		}
+	}
+}


### PR DESCRIPTION
Issue resolved (if any): #279

Description of this pull request:

It add an option tool for the endpoint connection,

you need to add `#config` or `#config:value` lines before the query you want to run

example with the `no_optimizer` config

```rq
#no_optimizer
SELECT * {
  ?s ?p ?o .
  <http://a> <http://p> ""
}
```

I've also added an option to add a value, maybe for later

```rq
#config_key:config value
SELECT * {
  ?s ?p ?o .
}
```

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
