### PR TITLE
GH-303 add file hashes in the release note

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -283,7 +283,14 @@ jobs:
         run: |
           mkdir -p deploy_file
           mv qendpoint.*/* deploy_file
-          mv qendpoint-cli.*/* deploy_file
+      - name: Compute hashes
+        run: |
+          echo "" >> release/SUFFIX.md
+          echo '**SHA512**' >> release/SUFFIX.md
+          echo '' >> release/SUFFIX.md
+          echo '```' >> release/SUFFIX.md
+          scripts/hashfiles.sh deploy_file >> release/SUFFIX.md
+          echo '```' >> release/SUFFIX.md
       - name: Create release body
         run: scripts/build_release_input.sh
       - name: Create release with artifacts

--- a/scripts/hashfiles.sh
+++ b/scripts/hashfiles.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+
+if (( $# < 1 )); then
+    1>&2 echo "$0 (input_directory)"
+    1>&2 echo "input_directory : directory to list the hashes"
+    exit -1
+fi
+BASE=`dirname $0`
+FILE=`realpath $1`
+
+cd $BASE/..
+
+for f in `ls $FILE` ; do
+    echo "$f : $(sha512sum -b "$FILE/$f" | cut -d " " -f 1)"
+done
+


### PR DESCRIPTION
Issue resolved (if any): #303 

Description of this pull request:

It will add the sha512 in the release notes

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [ ] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
