### PR TITLE
GH-280 add query plan in frontend

### DIFF
--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
@@ -4,7 +4,6 @@ import com.the_qa_company.qendpoint.store.EndpointStoreUtils;
 import com.the_qa_company.qendpoint.store.exception.EndpointStoreInputException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.tomcat.util.http.fileupload.MultipartStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebInputException;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -48,16 +46,18 @@ public class EndpointController {
 			@RequestParam(value = "update", required = false) final String updateQuery,
 			@RequestParam(value = "format", defaultValue = "json") final String format,
 			@RequestHeader(value = "Accept", defaultValue = "application/sparql-results+json") String acceptHeader,
+			@RequestHeader(value = "QueryConfig", defaultValue = "") String queryConfig,
 			@RequestHeader(value = "timeout", defaultValue = "-1") int timeout,
 			@RequestHeader(value = "Content-Type", defaultValue = "text/plain") String content,
 
 			@RequestBody(required = false) String body, HttpServletResponse response) throws IOException {
-		logger.info("New query");
 		try {
 			if (query != null) {
-				sparql.execute(query, timeout, acceptHeader, response::setContentType, response.getOutputStream());
+				sparql.execute(query, timeout, acceptHeader, response::setContentType, response.getOutputStream(),
+						queryConfig);
 			} else if (body != null && content.equals("application/sparql-query")) {
-				sparql.execute(body, timeout, acceptHeader, response::setContentType, response.getOutputStream());
+				sparql.execute(body, timeout, acceptHeader, response::setContentType, response.getOutputStream(),
+						queryConfig);
 			} else if (updateQuery != null) {
 				sparql.executeUpdate(updateQuery, timeout, response.getOutputStream());
 			} else if (body != null) {

--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
@@ -493,10 +493,10 @@ public class Sparql {
 	}
 
 	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,
-			OutputStream out) {
+			OutputStream out, String queryParam) {
 		waitLoading(1);
 		try {
-			sparqlRepository.execute(sparqlQuery, timeout, acceptHeader, mimeSetter, out);
+			sparqlRepository.execute(sparqlQuery, timeout, acceptHeader, mimeSetter, out, queryParam);
 		} finally {
 			completeQuery();
 		}

--- a/qendpoint-frontend/package-lock.json
+++ b/qendpoint-frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
+        "@triply/yasgui-utils": "^4.2.28",
         "@types/jest": "^26.0.15",
         "@types/node": "^16.0.0",
         "@types/react": "^17.0.0",

--- a/qendpoint-frontend/package.json
+++ b/qendpoint-frontend/package.json
@@ -38,6 +38,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "@triply/yasgui-utils": "^4.2.28",
     "@types/jest": "^26.0.15",
     "@types/node": "^16.0.0",
     "@types/react": "^17.0.0",

--- a/qendpoint-frontend/src/components/SparqlEndpoint/plugins/queryPlan.ts
+++ b/qendpoint-frontend/src/components/SparqlEndpoint/plugins/queryPlan.ts
@@ -24,7 +24,7 @@ const buildPlan = (plan: any) => {
 export default class QueryPlanPlugin {
   // A priority value. If multiple plugin support rendering of a result, this value is used
   // to select the correct plugin
-  priority = 10;
+  priority = 10
 
   // Whether to show a select-button for this plugin
   yasr: Yasr

--- a/qendpoint-frontend/src/components/SparqlEndpoint/plugins/queryPlan.ts
+++ b/qendpoint-frontend/src/components/SparqlEndpoint/plugins/queryPlan.ts
@@ -1,0 +1,68 @@
+import Yasr from '@triply/yasr'
+import * as faFlask from '@fortawesome/free-solid-svg-icons/faFlask'
+
+export interface PluginConfig {
+}
+
+const buildPlan = (plan: any) => {
+  const container = document.createElement('li')
+  const id = document.createElement('p')
+  id.innerText = plan.id
+  const ul = document.createElement('ul')
+  ul.style.listStyleType = 'circle'
+
+  if (plan.plans) {
+    plan.plans.forEach((pln: any) => {
+      ul.appendChild(buildPlan(pln))
+    })
+  }
+  container.appendChild(id)
+  container.appendChild(ul)
+  return container
+}
+
+export default class QueryPlanPlugin {
+  // A priority value. If multiple plugin support rendering of a result, this value is used
+  // to select the correct plugin
+  priority = 10;
+
+  // Whether to show a select-button for this plugin
+  yasr: Yasr
+
+  label = 'Query plan'
+
+  constructor (yasr: Yasr) {
+    this.yasr = yasr
+  }
+
+  // Draw the resultset. This plugin simply draws the string 'True' or 'False'
+  draw () {
+    const json = this.yasr.results?.getAsJson() as any
+    if (!json || !json.plan) {
+      const el = document.createElement('div')
+      el.innerHTML = 'No query plan found, please add <strong>#get_plan</strong> in you query to fetch it.'
+      this.yasr.resultsEl.appendChild(el)
+    } else {
+      const plan = json.plan
+      const plnEl = buildPlan(plan)
+      console.log(plnEl)
+      const container = document.createElement('ul')
+      container.appendChild(plnEl)
+      this.yasr.resultsEl.appendChild(container)
+    }
+  }
+
+  // A required function, used to indicate whether this plugin can draw the current
+  // resultset from yasr
+  canHandleResults () {
+    return true
+  }
+
+  // A required function, used to identify the plugin, works best with an svg
+  getIcon () {
+    const svgString = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${faFlask.width} ${faFlask.height}" aria-hidden="true"><path fill="currentColor" d="${faFlask.svgPathData}"></path></svg>`
+    const template = document.createElement('template')
+    template.innerHTML = svgString
+    return template.content.firstChild
+  }
+}


### PR DESCRIPTION
Issue resolved (if any): #280

Description of this pull request:

I've added the query plan, it looks like this:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/1580223/228228614-3f94e0a8-f927-43ef-9059-8e710a070bd3.png">

I've also added the `QueryConfig` header to the Sparql mapping to define config without having to specify it in the query

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
