### PR TITLE
GH-391 Dump dataset while running the endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ qendpoint-cli/*.iml
 qendpoint-cli/.idea/
 /qendpoint/
 /tests/
+/dump/
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 

--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
@@ -178,6 +178,11 @@ public class EndpointController {
 		return ResponseEntity.status(HttpStatus.OK).body(sparql.askForAMerge());
 	}
 
+	@GetMapping("/dump")
+	public ResponseEntity<Sparql.MergeRequestResult> dumpStore() {
+		return ResponseEntity.status(HttpStatus.OK).body(sparql.askForADump());
+	}
+
 	@GetMapping("/reindex")
 	public ResponseEntity<Sparql.LuceneIndexRequestResult> reindex() throws Exception {
 		return ResponseEntity.status(HttpStatus.OK).body(sparql.reindexLucene());

--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
@@ -49,6 +49,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.Map;
@@ -467,6 +469,22 @@ public class Sparql {
 		}
 		this.endpoint.mergeStore();
 		return new MergeRequestResult(true);
+	}
+
+	/**
+	 * ask for a merge of the endpoint store
+	 *
+	 * @return see
+	 *         {@link com.the_qa_company.qendpoint.store.EndpointStore#mergeStore()}
+	 *         return value
+	 */
+	public MergeRequestResult askForADump() {
+		if (endpoint == null) {
+			throw new ServerWebInputException("No endpoint store, bad config?");
+		}
+		Path outLocation = Path.of("dump")
+				.resolve(DateTimeFormatter.ofPattern("yyy-MM-dd HHmmss").format(LocalDateTime.now()));
+		return new MergeRequestResult(this.sparqlRepository.askDump(outLocation));
 	}
 
 	/**

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/ControlInformation.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/ControlInformation.java
@@ -25,12 +25,9 @@ import com.the_qa_company.qendpoint.core.util.crc.CRCInputStream;
 import com.the_qa_company.qendpoint.core.util.crc.CRCOutputStream;
 import com.the_qa_company.qendpoint.core.util.io.IOUtil;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Enumeration;
 
 /**
@@ -89,20 +86,6 @@ public class ControlInformation extends HDTOptionsBase implements ControlInfo {
 
 		// CRC
 		out.writeCRC();
-	}
-
-	@Override
-	public void load(String filename) throws IOException {
-		try (InputStream is = IOUtil.getFileInputStream(filename)) {
-			load(is);
-		}
-	}
-
-	@Override
-	public void load(Path filename) throws IOException {
-		try (InputStream is = new BufferedInputStream(Files.newInputStream(filename))) {
-			load(is);
-		}
 	}
 
 	@Override

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/CompiledSailEndpointStoreDump.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/CompiledSailEndpointStoreDump.java
@@ -1,0 +1,79 @@
+package com.the_qa_company.qendpoint.compiler;
+
+import com.the_qa_company.qendpoint.store.EndpointStore;
+import com.the_qa_company.qendpoint.store.EndpointStoreDump;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.eclipse.rdf4j.common.concurrent.locks.Lock;
+import org.eclipse.rdf4j.sail.lucene.LuceneSail;
+import org.eclipse.rdf4j.sail.lucene.impl.LuceneIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CompiledSailEndpointStoreDump extends EndpointStoreDump.EndpointStoreDumpDataset {
+	private static final Logger logger = LoggerFactory.getLogger(CompiledSailEndpointStoreDump.class);
+	private final CompiledSail compiledSail;
+
+	public CompiledSailEndpointStoreDump(Path outputLocation, CompiledSail compiledSail) {
+		super(outputLocation);
+		this.compiledSail = compiledSail;
+	}
+
+	@Override
+	public void beforeMerge(EndpointStore store) throws IOException {
+		// dump the Lucene dataset
+		Lock lock = store.getLocksNotify().createLock("merge-dumplucene");
+		StringBuilder infoWriter = new StringBuilder();
+		Path out = outputLocation.resolve("lucene");
+		try {
+			int ukn = 0;
+			Set<String> names = new HashSet<>();
+			for (LuceneSail ls : compiledSail.getLuceneSails()) {
+				if (!(ls.getLuceneIndex() instanceof LuceneIndex li)) {
+					logger.error("Can't dump index {}", ls.getLuceneIndex());
+					continue;
+				}
+				li.getIndexWriter().flush();
+
+				// find a unique name for the lucene dir
+				String configDir = ls.getParameter("lucenedir");
+				String name;
+				if (configDir == null || configDir.isEmpty()) {
+					name = "ukn_" + ukn++;
+				} else {
+					name = Path.of(configDir).getFileName().toString();
+				}
+
+				String tname = name;
+				int dif = 1;
+				while (!names.add(tname)) {
+					tname = name + "." + dif++;
+				}
+				Path outputDataset = out.resolve(tname);
+
+				// write dataset metadata
+				infoWriter.append("location=%s\noutput=%s\n---\n".formatted(configDir, outputDataset));
+
+				// clone the index
+				Files.createDirectories(outputDataset);
+				Directory lsdir = li.getDirectory();
+				try (FSDirectory dir = FSDirectory.open(outputDataset)) {
+					for (String file : lsdir.listAll()) {
+						dir.copyFrom(lsdir, file, file, new IOContext());
+					}
+				}
+			}
+			Files.writeString(outputLocation.resolve("lucene.info"), infoWriter.toString());
+		} finally {
+			lock.release();
+		}
+		super.beforeMerge(store);
+	}
+}

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
@@ -147,6 +147,17 @@ public class SparqlRepository {
 	}
 
 	/**
+	 * Dump the store, this method will call
+	 * {@link CompiledSail#dumpStore(Path)}
+	 *
+	 * @param location location
+	 * @return if the dump was started
+	 */
+	public boolean askDump(Path location) {
+		return compiledSail.dumpStore(location);
+	}
+
+	/**
 	 * execute a sparql query
 	 *
 	 * @param sparqlQuery  the query

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreConnection.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreConnection.java
@@ -119,12 +119,22 @@ public class EndpointStoreConnection extends SailSourceConnection implements Con
 
 	@Override
 	protected void notifyStatementAdded(Statement st) {
+		try {
+			endpoint.getLocksNotify().waitForActiveLocks();
+		} catch (InterruptedException e) {
+			throw new SailException(e);
+		}
 		HDTConverter converter = endpoint.getHdtConverter();
 		super.notifyStatementAdded(converter.delegate(converter.rdf4ToHdt(st)));
 	}
 
 	@Override
 	protected void notifyStatementRemoved(Statement st) {
+		try {
+			endpoint.getLocksNotify().waitForActiveLocks();
+		} catch (InterruptedException e) {
+			throw new SailException(e);
+		}
 		HDTConverter converter = endpoint.getHdtConverter();
 		super.notifyStatementRemoved(converter.delegate(converter.rdf4ToHdt(st)));
 	}

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreDump.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreDump.java
@@ -1,0 +1,51 @@
+package com.the_qa_company.qendpoint.store;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * information on how a {@link EndpointStore} should be dumped
+ *
+ * @author Antoine Willerval
+ */
+public interface EndpointStoreDump {
+
+	static EndpointStoreDump dataset(Path outputLocation) {
+		return new EndpointStoreDumpDataset(outputLocation);
+	}
+
+	/**
+	 * call before the dataset catdiff
+	 *
+	 * @param store store
+	 * @throws IOException io exception
+	 */
+	default void beforeMerge(EndpointStore store) throws IOException {
+	}
+
+	/**
+	 * call after the dataset catdiff
+	 *
+	 * @param store         store
+	 * @param mergedDataset path were the dataset was catdiff
+	 * @throws IOException io exception
+	 */
+	default void afterMerge(EndpointStore store, Path mergedDataset) throws IOException {
+	}
+
+	class EndpointStoreDumpDataset implements EndpointStoreDump {
+		protected final Path outputLocation;
+
+		public EndpointStoreDumpDataset(Path outputLocation) {
+			this.outputLocation = outputLocation;
+		}
+
+		@Override
+		public void afterMerge(EndpointStore store, Path mergedDataset) throws IOException {
+			Files.createDirectories(outputLocation.getParent());
+			// store the dataset
+			Files.copy(mergedDataset, outputLocation.resolve("store.hdt"));
+		}
+	}
+}

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/utils/FileUtils.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/utils/FileUtils.java
@@ -8,6 +8,9 @@ import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Utility class to manage files


### PR DESCRIPTION
Issue resolved (if any): #391 

Description of this pull request:

A not optimized system to dump the dataset from a running endpointstore, it uses 2 particular states of the endpoint during the merge

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
