### PR TITLE
GH-399 support [AUTO_LANGUAGE]

### DIFF
--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/EndpointController.java
@@ -46,6 +46,7 @@ public class EndpointController {
 			@RequestParam(value = "update", required = false) final String updateQuery,
 			@RequestParam(value = "format", defaultValue = "json") final String format,
 			@RequestHeader(value = "Accept", defaultValue = "application/sparql-results+json") String acceptHeader,
+			@RequestHeader(value = "Accept-Language", defaultValue = "en") String acceptLanguageHeader,
 			@RequestHeader(value = "QueryConfig", defaultValue = "") String queryConfig,
 			@RequestHeader(value = "timeout", defaultValue = "-1") int timeout,
 			@RequestHeader(value = "Content-Type", defaultValue = "text/plain") String content,
@@ -53,11 +54,11 @@ public class EndpointController {
 			@RequestBody(required = false) String body, HttpServletResponse response) throws IOException {
 		try {
 			if (query != null) {
-				sparql.execute(query, timeout, acceptHeader, response::setContentType, response.getOutputStream(),
-						queryConfig);
+				sparql.execute(query, timeout, acceptHeader, acceptLanguageHeader, response::setContentType,
+						response.getOutputStream(), queryConfig);
 			} else if (body != null && content.equals("application/sparql-query")) {
-				sparql.execute(body, timeout, acceptHeader, response::setContentType, response.getOutputStream(),
-						queryConfig);
+				sparql.execute(body, timeout, acceptHeader, acceptLanguageHeader, response::setContentType,
+						response.getOutputStream(), queryConfig);
 			} else if (updateQuery != null) {
 				sparql.executeUpdate(updateQuery, timeout, response.getOutputStream());
 			} else if (body != null) {

--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
@@ -533,11 +533,12 @@ public class Sparql {
 		return new HasLuceneIndexResult(sparqlRepository.hasLuceneSail());
 	}
 
-	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,
-			OutputStream out, String queryParam) {
+	public void execute(String sparqlQuery, int timeout, String acceptHeader, String acceptLanguageHeader,
+			Consumer<String> mimeSetter, OutputStream out, String queryParam) {
 		waitLoading(1);
 		try {
-			sparqlRepository.execute(sparqlQuery, timeout, acceptHeader, mimeSetter, out, queryParam);
+			sparqlRepository.execute(sparqlQuery, timeout, acceptHeader, acceptLanguageHeader, mimeSetter, out,
+					queryParam);
 		} finally {
 			completeQuery();
 		}

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
@@ -550,9 +550,9 @@ public class SparqlRepository {
 				}
 			}
 
-		if (compiledSail.getOptions().isDebugShowPlans()) {
-			System.out.println(parsedQuery);
-		}
+			if (compiledSail.getOptions().isDebugShowPlans()) {
+				System.out.println(parsedQuery);
+			}
 
 			if (parsedQuery instanceof ParsedTupleQuery) {
 				TupleQuery query = connection.prepareTupleQuery(sparqlQuery);

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
@@ -133,6 +133,75 @@ public class SparqlRepository {
 	/**
 	 * execute a sparql query
 	 *
+	 * @param sparqlQuery  the query
+	 * @param timeout      query timeout
+	 * @param acceptHeader accept header
+	 * @param mimeSetter   mime setter, null for no set
+	 * @param out          output stream
+	 * @param queryParam   query parameters
+	 * @throws java.lang.NullPointerException if an argument is null
+	 */
+	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,
+			OutputStream out, String queryParam) {
+		execute(null, sparqlQuery, timeout, acceptHeader, null, mimeSetter, out, queryParam);
+	}
+
+	/**
+	 * execute a sparql query
+	 *
+	 * @param sparqlQuery  the query
+	 * @param timeout      query timeout
+	 * @param acceptHeader accept header
+	 * @param mimeSetter   mime setter, null for no set
+	 * @param out          output stream
+	 * @throws java.lang.NullPointerException if an argument is null
+	 */
+	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,
+			OutputStream out) {
+		execute(sparqlQuery, timeout, acceptHeader, null, mimeSetter, out, "");
+	}
+
+	/**
+	 * execute a sparql query
+	 *
+	 * @param connection   the connection to use
+	 * @param sparqlQuery  the query
+	 * @param timeout      query timeout
+	 * @param acceptHeader accept header
+	 * @param mimeSetter   mime setter, null for no set
+	 * @param out          output stream
+	 * @param queryParam   query parameters
+	 * @throws java.lang.NullPointerException if an argument is null
+	 */
+	public void execute(RepositoryConnection connection, String sparqlQuery, int timeout, String acceptHeader,
+			Consumer<String> mimeSetter, OutputStream out, String queryParam) {
+		Objects.requireNonNull(sparqlQuery, "sparqlQuery can't be null");
+		Objects.requireNonNull(acceptHeader, "acceptHeader can't be null");
+		mimeSetter = Objects.requireNonNullElseGet(mimeSetter, () -> s -> {});
+		Objects.requireNonNull(out, "output stream can't be null");
+
+		execute0(connection, sparqlQuery, timeout, acceptHeader, null, mimeSetter, out, queryParam);
+	}
+
+	/**
+	 * execute a sparql query
+	 *
+	 * @param connection   the connection to use
+	 * @param sparqlQuery  the query
+	 * @param timeout      query timeout
+	 * @param acceptHeader accept header
+	 * @param mimeSetter   mime setter, null for no set
+	 * @param out          output stream
+	 * @throws java.lang.NullPointerException if an argument is null
+	 */
+	public void execute(RepositoryConnection connection, String sparqlQuery, int timeout, String acceptHeader,
+			Consumer<String> mimeSetter, OutputStream out) {
+		execute(connection, sparqlQuery, timeout, acceptHeader, null, mimeSetter, out, "");
+	}
+
+	/**
+	 * execute a sparql query
+	 *
 	 * @param sparqlQuery          the query
 	 * @param timeout              query timeout
 	 * @param acceptHeader         accept header

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SparqlRepository.java
@@ -7,50 +7,30 @@ import com.the_qa_company.qendpoint.store.EndpointStoreConnection;
 import com.the_qa_company.qendpoint.store.exception.EndpointStoreInputException;
 import com.the_qa_company.qendpoint.utils.FormatUtils;
 import com.the_qa_company.qendpoint.utils.RDFStreamUtils;
-import com.the_qa_company.qendpoint.utils.rdf.BooleanQueryResult;
-import com.the_qa_company.qendpoint.utils.rdf.ClosableResult;
-import com.the_qa_company.qendpoint.utils.rdf.QEPSPARQLResultsJSONWriter;
-import com.the_qa_company.qendpoint.utils.rdf.QueryResultCounter;
-import com.the_qa_company.qendpoint.utils.rdf.RDFHandlerCounter;
+import com.the_qa_company.qendpoint.utils.rdf.*;
 import com.the_qa_company.qendpoint.utils.sail.SourceSailConnectionWrapper;
 import jakarta.json.Json;
 import jakarta.json.stream.JsonGenerator;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Values;
-import org.eclipse.rdf4j.query.BooleanQuery;
-import org.eclipse.rdf4j.query.GraphQuery;
-import org.eclipse.rdf4j.query.GraphQueryResult;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.query.TupleQueryResultHandler;
-import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.explanation.Explanation;
 import org.eclipse.rdf4j.query.explanation.GenericPlanNode;
-import org.eclipse.rdf4j.query.parser.ParsedBooleanQuery;
-import org.eclipse.rdf4j.query.parser.ParsedGraphQuery;
-import org.eclipse.rdf4j.query.parser.ParsedQuery;
-import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
-import org.eclipse.rdf4j.query.parser.QueryParserUtil;
-import org.eclipse.rdf4j.query.parser.QueryPrologLexer;
+import org.eclipse.rdf4j.query.parser.*;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLQueries;
-import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.QueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterRegistry;
+import org.eclipse.rdf4j.query.resultio.*;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.rio.ParserConfig;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandler;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.sail.SailConnection;
@@ -63,14 +43,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -160,70 +133,74 @@ public class SparqlRepository {
 	/**
 	 * execute a sparql query
 	 *
-	 * @param sparqlQuery  the query
-	 * @param timeout      query timeout
-	 * @param acceptHeader accept header
-	 * @param mimeSetter   mime setter, null for no set
-	 * @param out          output stream
-	 * @param queryParam   query parameters
+	 * @param sparqlQuery          the query
+	 * @param timeout              query timeout
+	 * @param acceptHeader         accept header
+	 * @param acceptLanguageHeader accept-language header
+	 * @param mimeSetter           mime setter, null for no set
+	 * @param out                  output stream
+	 * @param queryParam           query parameters
 	 * @throws java.lang.NullPointerException if an argument is null
 	 */
-	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,
-			OutputStream out, String queryParam) {
-		execute(null, sparqlQuery, timeout, acceptHeader, mimeSetter, out, queryParam);
+	public void execute(String sparqlQuery, int timeout, String acceptHeader, String acceptLanguageHeader,
+			Consumer<String> mimeSetter, OutputStream out, String queryParam) {
+		execute(null, sparqlQuery, timeout, acceptHeader, acceptLanguageHeader, mimeSetter, out, queryParam);
 	}
 
 	/**
 	 * execute a sparql query
 	 *
-	 * @param sparqlQuery  the query
-	 * @param timeout      query timeout
-	 * @param acceptHeader accept header
-	 * @param mimeSetter   mime setter, null for no set
-	 * @param out          output stream
+	 * @param sparqlQuery          the query
+	 * @param timeout              query timeout
+	 * @param acceptHeader         accept header
+	 * @param acceptLanguageHeader accept-language header
+	 * @param mimeSetter           mime setter, null for no set
+	 * @param out                  output stream
 	 * @throws java.lang.NullPointerException if an argument is null
 	 */
-	public void execute(String sparqlQuery, int timeout, String acceptHeader, Consumer<String> mimeSetter,
-			OutputStream out) {
-		execute(sparqlQuery, timeout, acceptHeader, mimeSetter, out, "");
+	public void execute(String sparqlQuery, int timeout, String acceptHeader, String acceptLanguageHeader,
+			Consumer<String> mimeSetter, OutputStream out) {
+		execute(sparqlQuery, timeout, acceptHeader, acceptLanguageHeader, mimeSetter, out, "");
 	}
 
 	/**
 	 * execute a sparql query
 	 *
-	 * @param connection   the connection to use
-	 * @param sparqlQuery  the query
-	 * @param timeout      query timeout
-	 * @param acceptHeader accept header
-	 * @param mimeSetter   mime setter, null for no set
-	 * @param out          output stream
-	 * @param queryParam   query parameters
+	 * @param connection           the connection to use
+	 * @param sparqlQuery          the query
+	 * @param timeout              query timeout
+	 * @param acceptHeader         accept header
+	 * @param acceptLanguageHeader accept-language header
+	 * @param mimeSetter           mime setter, null for no set
+	 * @param out                  output stream
+	 * @param queryParam           query parameters
 	 * @throws java.lang.NullPointerException if an argument is null
 	 */
 	public void execute(RepositoryConnection connection, String sparqlQuery, int timeout, String acceptHeader,
-			Consumer<String> mimeSetter, OutputStream out, String queryParam) {
+			String acceptLanguageHeader, Consumer<String> mimeSetter, OutputStream out, String queryParam) {
 		Objects.requireNonNull(sparqlQuery, "sparqlQuery can't be null");
 		Objects.requireNonNull(acceptHeader, "acceptHeader can't be null");
 		mimeSetter = Objects.requireNonNullElseGet(mimeSetter, () -> s -> {});
 		Objects.requireNonNull(out, "output stream can't be null");
 
-		execute0(connection, sparqlQuery, timeout, acceptHeader, mimeSetter, out, queryParam);
+		execute0(connection, sparqlQuery, timeout, acceptHeader, acceptLanguageHeader, mimeSetter, out, queryParam);
 	}
 
 	/**
 	 * execute a sparql query
 	 *
-	 * @param connection   the connection to use
-	 * @param sparqlQuery  the query
-	 * @param timeout      query timeout
-	 * @param acceptHeader accept header
-	 * @param mimeSetter   mime setter, null for no set
-	 * @param out          output stream
+	 * @param connection           the connection to use
+	 * @param sparqlQuery          the query
+	 * @param timeout              query timeout
+	 * @param acceptHeader         accept header
+	 * @param acceptLanguageHeader accept-language header
+	 * @param mimeSetter           mime setter, null for no set
+	 * @param out                  output stream
 	 * @throws java.lang.NullPointerException if an argument is null
 	 */
 	public void execute(RepositoryConnection connection, String sparqlQuery, int timeout, String acceptHeader,
-			Consumer<String> mimeSetter, OutputStream out) {
-		execute(connection, sparqlQuery, timeout, acceptHeader, mimeSetter, out, "");
+			String acceptLanguageHeader, Consumer<String> mimeSetter, OutputStream out) {
+		execute(connection, sparqlQuery, timeout, acceptHeader, acceptLanguageHeader, mimeSetter, out, "");
 	}
 
 	/**
@@ -244,7 +221,7 @@ public class SparqlRepository {
 	 * @param timeout     query timeout
 	 */
 	public ClosableResult<?> execute(RepositoryConnection connection, String sparqlQuery, int timeout) {
-		return execute0(connection, sparqlQuery, timeout, null, null, null, "");
+		return execute0(connection, sparqlQuery, timeout, null, null, null, null, "");
 	}
 
 	/**
@@ -271,7 +248,7 @@ public class SparqlRepository {
 	@SuppressWarnings("unchecked")
 	public ClosableResult<TupleQueryResult> executeTupleQuery(RepositoryConnection connection, String sparqlQuery,
 			int timeout) {
-		ClosableResult<?> res = execute0(connection, sparqlQuery, timeout, null, null, null, "");
+		ClosableResult<?> res = execute0(connection, sparqlQuery, timeout, null, null, null, null, "");
 		assert res != null;
 		if (!(res.getResult() instanceof TupleQueryResult)) {
 			try {
@@ -315,7 +292,7 @@ public class SparqlRepository {
 	 *                                                          be closed
 	 */
 	public boolean executeBooleanQuery(RepositoryConnection connection, String sparqlQuery, int timeout) {
-		ClosableResult<?> res = execute0(connection, sparqlQuery, timeout, null, null, null, "");
+		ClosableResult<?> res = execute0(connection, sparqlQuery, timeout, null, null, null, null, "");
 		assert res != null;
 		try {
 			if (!(res.getResult() instanceof BooleanQueryResult)) {
@@ -354,7 +331,7 @@ public class SparqlRepository {
 	@SuppressWarnings("unchecked")
 	public ClosableResult<GraphQueryResult> executeGraphQuery(RepositoryConnection connection, String sparqlQuery,
 			int timeout) {
-		ClosableResult<?> res = execute0(connection, sparqlQuery, timeout, null, null, null, "");
+		ClosableResult<?> res = execute0(connection, sparqlQuery, timeout, null, null, null, null, "");
 		assert res != null;
 		if (!(res.getResult() instanceof GraphQueryResult)) {
 			try {
@@ -436,7 +413,8 @@ public class SparqlRepository {
 	 *         for boolean queries
 	 */
 	private ClosableResult<?> execute0(RepositoryConnection customConnection, String sparqlQuery, int timeout,
-			String acceptHeader, Consumer<String> mimeSetter, OutputStream out, String queryParam) {
+			String acceptHeader, String acceptLanguageHeader, Consumer<String> mimeSetter, OutputStream out,
+			String queryParam) {
 
 		if (sparqlQuery.isEmpty()) {
 			throw new EndpointStoreInputException("Empty query");
@@ -541,9 +519,40 @@ public class SparqlRepository {
 
 			ParsedQuery parsedQuery = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, sparqlQuery, null);
 
-			if (compiledSail.getOptions().isDebugShowPlans()) {
-				System.out.println(parsedQuery);
+			// Substitute [AUTO_LANGUAGE] with the client's language
+			if (acceptLanguageHeader != null) {
+				List<Locale.LanguageRange> languageRanges = Locale.LanguageRange.parse(acceptLanguageHeader);
+				Locale locale = Locale.lookup(languageRanges, Arrays.asList(Locale.getAvailableLocales()));
+				try {
+					parsedQuery.getTupleExpr().visit(new AbstractQueryModelVisitor<Exception>() {
+						@Override
+						public void meet(Var node) throws Exception {
+							if (node.getValue() instanceof Literal literal) {
+								boolean isStringDatatype = literal.getDatatype() == null
+										|| literal.getDatatype().equals(CoreDatatype.XSD.STRING.getIri());
+								if (isStringDatatype) {
+									String value = literal.getLabel();
+									if (value.equals("[AUTO_LANGUAGE]")) {
+										ValueFactory vf = SimpleValueFactory.getInstance();
+										Literal newLiteral = vf.createLiteral(locale.getLanguage());
+										Var newVar = new Var(node.getName(), newLiteral);
+										node.replaceWith(newVar);
+									}
+								}
+							}
+							super.meet(node);
+						}
+					});
+				} catch (Exception e) {
+					logger.error("This exception was caught [" + e + "]");
+					e.printStackTrace();
+					throw new RuntimeException(e);
+				}
 			}
+
+		if (compiledSail.getOptions().isDebugShowPlans()) {
+			System.out.println(parsedQuery);
+		}
 
 			if (parsedQuery instanceof ParsedTupleQuery) {
 				TupleQuery query = connection.prepareTupleQuery(sparqlQuery);

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/federation/SPARQLServiceWikibaseLabelResolver.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/federation/SPARQLServiceWikibaseLabelResolver.java
@@ -7,17 +7,19 @@ import org.eclipse.rdf4j.repository.sparql.federation.SPARQLFederatedService;
 import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver;
 
 public class SPARQLServiceWikibaseLabelResolver extends SPARQLServiceResolver {
-	TripleSource tripleSource;
+	private final TripleSource tripleSource;
+	private final String userLocales;
 
-	public SPARQLServiceWikibaseLabelResolver(TripleSource tripleSource) {
+	public SPARQLServiceWikibaseLabelResolver(TripleSource tripleSource, String userLocales) {
 		this.tripleSource = tripleSource;
+		this.userLocales = userLocales;
 	}
 
 	@Override
 	protected FederatedService createService(String serviceUrl) throws QueryEvaluationException {
 		// for the Wikibase url use a spacial FederatedService implementation
 		if (serviceUrl.equals("http://wikiba.se/ontology#label")) {
-			return new WikibaseLabelService(tripleSource);
+			return new WikibaseLabelService(tripleSource, userLocales);
 		} else {
 			return new SPARQLFederatedService(serviceUrl, this.getHttpClientSessionManager());
 		}

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStore.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStore.java
@@ -73,6 +73,10 @@ public class EndpointStore extends AbstractNotifyingSail {
 	 * get the query plan
 	 */
 	public static final String QUERY_CONFIG_FETCH_QUERY_PLAN = "get_plan";
+	/**
+	 * set the user locales
+	 */
+	public static final String QUERY_CONFIG_USER_LOCALES = "user_locales";
 	private static final AtomicLong ENDPOINT_DEBUG_ID_GEN = new AtomicLong();
 	private static final Logger logger = LoggerFactory.getLogger(EndpointStore.class);
 	private final long debugId;

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreQueryPreparer.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreQueryPreparer.java
@@ -106,7 +106,9 @@ public class EndpointStoreQueryPreparer extends AbstractQueryPreparer {
 			tupleExpr = new QueryRoot(tupleExpr);
 		}
 		EvaluationStrategy strategy = new ExtendedEvaluationStrategy(getTripleSource(), dataset,
-				new SPARQLServiceWikibaseLabelResolver(tripleSource), 0L, evaluationStatistics);
+				new SPARQLServiceWikibaseLabelResolver(tripleSource,
+						conn.getConfig(EndpointStore.QUERY_CONFIG_USER_LOCALES)),
+				0L, evaluationStatistics);
 
 		if (this.trackResultSize) {
 			strategy.setTrackResultSize(this.trackResultSize);


### PR DESCRIPTION
Issue resolved (if any): #399 

Description of this pull request:

Handle `AcceptLanguage` header in controller.

Add `acceptLanguageHeader` parameter to some of `Sparql::execute` methods.

Use an `AbstractQueryModelVisitor` to find the `"[AUTO_LANGUAGE]"` literal and replace it according to the accept header.

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [ ] I've squashed my commits (if necessary)
