### PR TITLE
GH-440 Add delete bitmap to multiple co-indexes

### DIFF
--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/HDTImpl.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/hdt/impl/HDTImpl.java
@@ -333,6 +333,11 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 				public TripleComponentOrder getOrder() {
 					return TripleComponentOrder.getAcceptableOrder(searchOrderMask);
 				}
+
+				@Override
+				public boolean isLastTriplePositionBoundToOrder() {
+					return false;
+				}
 			};
 		}
 
@@ -410,6 +415,11 @@ public class HDTImpl extends HDTBase<HeaderPrivate, DictionaryPrivate, TriplesPr
 				@Override
 				public TripleComponentOrder getOrder() {
 					return TripleComponentOrder.getAcceptableOrder(searchOrderMask);
+				}
+
+				@Override
+				public boolean isLastTriplePositionBoundToOrder() {
+					return false;
 				}
 			};
 		}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/header/PlainHeaderIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/header/PlainHeaderIterator.java
@@ -116,4 +116,9 @@ public class PlainHeaderIterator implements IteratorTripleString {
 	public TripleComponentOrder getOrder() {
 		return TripleComponentOrder.Unknown;
 	}
+
+	@Override
+	public boolean isLastTriplePositionBoundToOrder() {
+		return false;
+	}
 }

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/DictionaryTranslateIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/DictionaryTranslateIterator.java
@@ -167,4 +167,9 @@ public class DictionaryTranslateIterator implements IteratorTripleString {
 		return iterator.getOrder();
 	}
 
+	@Override
+	public boolean isLastTriplePositionBoundToOrder() {
+		return iterator.isLastTriplePositionBoundToOrder();
+	}
+
 }

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/DictionaryTranslateIteratorBuffer.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/iterator/DictionaryTranslateIteratorBuffer.java
@@ -284,6 +284,11 @@ public class DictionaryTranslateIteratorBuffer implements IteratorTripleString {
 		return iterator.getOrder();
 	}
 
+	@Override
+	public boolean isLastTriplePositionBoundToOrder() {
+		return iterator.isLastTriplePositionBoundToOrder();
+	}
+
 	public static void setBlockSize(int size) {
 		DEFAULT_BLOCK_SIZE = size;
 	}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/rdf/parsers/JenaModelIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/rdf/parsers/JenaModelIterator.java
@@ -60,4 +60,8 @@ public class JenaModelIterator implements IteratorTripleString {
 		return TripleComponentOrder.Unknown;
 	}
 
+	@Override
+	public boolean isLastTriplePositionBoundToOrder() {
+		return false;
+	}
 }

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/IteratorTripleID.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/IteratorTripleID.java
@@ -19,10 +19,10 @@
 
 package com.the_qa_company.qendpoint.core.triples;
 
-import java.util.Iterator;
-
 import com.the_qa_company.qendpoint.core.enums.ResultEstimationType;
 import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+
+import java.util.Iterator;
 
 /**
  * Iterator of TripleID
@@ -95,4 +95,12 @@ public interface IteratorTripleID extends Iterator<TripleID> {
 	 * @see Triples#findTriple(long)
 	 */
 	long getLastTriplePosition();
+
+	/**
+	 * @return if the {@link #getLastTriplePosition()} function is returning an
+	 *         index based on {@link #getOrder()} or the triples order
+	 */
+	default boolean isLastTriplePositionBoundToOrder() {
+		return false;
+	}
 }

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/IteratorTripleString.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/IteratorTripleString.java
@@ -63,4 +63,6 @@ public interface IteratorTripleString extends Iterator<TripleString> {
 	 * @return order of the components from the iterator
 	 */
 	TripleComponentOrder getOrder();
+
+	boolean isLastTriplePositionBoundToOrder();
 }

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriplesIterator.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriplesIterator.java
@@ -293,4 +293,9 @@ public class BitmapTriplesIterator implements SuppliableIteratorTripleID {
 	public long getLastTriplePosition() {
 		return lastPosition;
 	}
+
+	@Override
+	public boolean isLastTriplePositionBoundToOrder() {
+		return true;
+	}
 }

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointFiles.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointFiles.java
@@ -1,6 +1,7 @@
 package com.the_qa_company.qendpoint.store;
 
 import com.the_qa_company.qendpoint.compiler.ParsedStringValue;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.core.hdt.HDTVersion;
 
 import java.io.File;
@@ -226,27 +227,33 @@ public class EndpointFiles {
 	 * @return the delete triple
 	 *         {@link com.the_qa_company.qendpoint.utils.BitArrayDisk} file
 	 */
-	@ParsedStringValue("store.deleteBitmap")
-	public String getTripleDeleteArr() {
-		return this.locationHdt + "triples-delete.arr";
+	public String getTripleDeleteArr(TripleComponentOrder order) {
+		if (order == TripleComponentOrder.SPO) {
+			return this.locationHdt + "triples-delete.arr";
+		}
+		return this.locationHdt + "triples-delete-" + order.name().toLowerCase() + ".arr";
 	}
 
 	/**
 	 * @return the temp delete triple
 	 *         {@link com.the_qa_company.qendpoint.utils.BitArrayDisk} file
 	 */
-	@ParsedStringValue("store.tempDeleteBitmap")
-	public String getTripleDeleteTempArr() {
-		return this.locationHdt + "triples-delete-temp.arr";
+	public String getTripleDeleteTempArr(TripleComponentOrder order) {
+		if (order == TripleComponentOrder.SPO) {
+			return this.locationHdt + "triples-delete-temp.arr";
+		}
+		return this.locationHdt + "triples-delete-" + order.name().toLowerCase() + "-temp.arr";
 	}
 
 	/**
 	 * @return the copy delete triple
 	 *         {@link com.the_qa_company.qendpoint.utils.BitArrayDisk} file
 	 */
-	@ParsedStringValue("store.tempDeleteBitmapCopy")
-	public String getTripleDeleteCopyArr() {
-		return this.locationHdt + "triples-delete-cpy.arr";
+	public String getTripleDeleteCopyArr(TripleComponentOrder order) {
+		if (order == TripleComponentOrder.SPO) {
+			return this.locationHdt + "triples-delete-cpy.arr";
+		}
+		return this.locationHdt + "triples-delete-" + order.name().toLowerCase() + "-cpy.arr";
 	}
 
 	/**

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreTripleIterator.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreTripleIterator.java
@@ -1,5 +1,6 @@
 package com.the_qa_company.qendpoint.store;
 
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.store.exception.EndpointTimeoutException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
@@ -52,7 +53,9 @@ public class EndpointStoreTripleIterator implements CloseableIteration<Statement
 		while (iterator.hasNext()) {
 			TripleID tripleID = iterator.next();
 			long index = iterator.getLastTriplePosition();
-			if (!endpoint.getDeleteBitMap().access(index)) {
+			TripleComponentOrder order = iterator.isLastTriplePositionBoundToOrder() ? iterator.getOrder()
+					: TripleComponentOrder.SPO;
+			if (!endpoint.getDeleteBitMap(order).access(index)) {
 				Resource subject = endpoint.getHdtConverter().idToSubjectHDTResource(tripleID.getSubject());
 				IRI predicate = endpoint.getHdtConverter().idToPredicateHDTResource(tripleID.getPredicate());
 				Value object = endpoint.getHdtConverter().idToObjectHDTResource(tripleID.getObject());

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/tools/QEPSearch.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/tools/QEPSearch.java
@@ -7,6 +7,7 @@ import com.the_qa_company.qendpoint.core.compact.bitmap.Bitmap64Big;
 import com.the_qa_company.qendpoint.core.compact.sequence.SequenceLog64BigDisk;
 import com.the_qa_company.qendpoint.core.dictionary.DictionarySection;
 import com.the_qa_company.qendpoint.core.dictionary.impl.MultipleBaseDictionary;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.core.enums.TripleComponentRole;
 import com.the_qa_company.qendpoint.core.exceptions.NotFoundException;
 import com.the_qa_company.qendpoint.core.exceptions.ParserException;
@@ -623,7 +624,7 @@ public class QEPSearch {
 						size = ep.getHdt().getDictionary().getNobjects() - shared;
 					}
 					case "bitd" -> {
-						bm = ep.getDeleteBitMap();
+						bm = ep.getDeleteBitMap(TripleComponentOrder.SPO);
 						size = ep.getHdt().getTriples().getNumberOfElements();
 					}
 					default -> {

--- a/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/EndpointMultIndexSPARQL11QueryComplianceTest.java
+++ b/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/EndpointMultIndexSPARQL11QueryComplianceTest.java
@@ -1,0 +1,153 @@
+package com.the_qa_company.qendpoint.store;
+
+import com.the_qa_company.qendpoint.core.enums.RDFNotation;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+import com.the_qa_company.qendpoint.core.exceptions.NotFoundException;
+import com.the_qa_company.qendpoint.core.exceptions.ParserException;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.hdt.HDTManager;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.triples.impl.BitmapTriplesIndexFile;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest.SPARQL11QueryComplianceTest;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class EndpointMultIndexSPARQL11QueryComplianceTest extends SPARQL11QueryComplianceTest {
+	private static final Logger logger = LoggerFactory.getLogger(EndpointSPARQL11QueryComplianceTest.class);
+
+	public EndpointMultIndexSPARQL11QueryComplianceTest(String displayName, String testURI, String name,
+			String queryFileURL, String resultFileURL, Dataset dataset, boolean ordered, boolean laxCardinality)
+			throws ParserException, NotFoundException, IOException {
+		super(displayName, testURI, name, queryFileURL, resultFileURL, null, ordered, laxCardinality);
+		setUpHDT(dataset);
+		List<String> testToIgnore = new ArrayList<>();
+		// @todo these tests are failing and should not, they are skipped so
+		// that we can be sure that we see when
+		// currently passing tests are not failing. Many of these tests are not
+		// so problematic since we do not support
+		// named graphs anyway
+		testToIgnore.add("constructwhere02 - CONSTRUCT WHERE");
+		testToIgnore.add("constructwhere03 - CONSTRUCT WHERE");
+		testToIgnore.add("constructwhere04 - CONSTRUCT WHERE");
+		testToIgnore.add("Exists within graph pattern");
+		testToIgnore.add("(pp07) Path with one graph");
+		testToIgnore.add("(pp35) Named Graph 2");
+		testToIgnore.add("sq01 - Subquery within graph pattern");
+		testToIgnore.add("sq02 - Subquery within graph pattern, graph variable is bound");
+		testToIgnore.add("sq03 - Subquery within graph pattern, graph variable is not bound");
+		testToIgnore.add("sq04 - Subquery within graph pattern, default graph does not apply");
+		testToIgnore.add("sq05 - Subquery within graph pattern, from named applies");
+		testToIgnore.add("sq06 - Subquery with graph pattern, from named applies");
+		testToIgnore.add("sq07 - Subquery with from ");
+		testToIgnore.add("sq11 - Subquery limit per resource");
+		testToIgnore.add("sq13 - Subqueries don't inject bindings");
+		testToIgnore.add("sq14 - limit by resource");
+
+		this.setIgnoredTests(testToIgnore);
+	}
+
+	@Rule
+	public TemporaryFolder tempDir = TemporaryFolder.builder().assureDeletion().build();
+
+	EndpointStore endpoint;
+	File nativeStore;
+	File hdtStore;
+
+	@Override
+	protected Repository newRepository() throws Exception {
+		nativeStore = tempDir.newFolder();
+		hdtStore = tempDir.newFolder();
+
+		HDTOptions spec = HDTOptions.of(HDTOptionsKeys.DICTIONARY_TYPE_KEY,
+				HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS, HDTOptionsKeys.BITMAPTRIPLES_INDEX_OTHERS,
+				EnumSet.of(TripleComponentOrder.SPO, TripleComponentOrder.OPS, TripleComponentOrder.PSO));
+		Path fileName = Path.of(hdtStore.getAbsolutePath() + "/" + EndpointStoreTest.HDT_INDEX_NAME);
+		if (this.hdt == null) {
+			hdt = Utility.createTempHdtIndex(tempDir, true, false, spec);
+		}
+		assert hdt != null;
+
+		hdt.saveToHDT(fileName, null);
+
+		endpoint = new EndpointStore(hdtStore.getAbsolutePath() + "/", EndpointStoreTest.HDT_INDEX_NAME, spec,
+				nativeStore.getAbsolutePath() + "/", true) {
+			@Override
+			public HDT loadIndex() throws IOException {
+				HDT idx = super.loadIndex();
+				if (idx.getTriples().getNumberOfElements() == 0) {
+					return idx;
+				}
+				try {
+					Path fileOPS = BitmapTriplesIndexFile.getIndexPath(fileName, TripleComponentOrder.OPS);
+					Assert.assertTrue("can't find " + fileOPS, Files.exists(fileOPS));
+					Path filePSO = BitmapTriplesIndexFile.getIndexPath(fileName, TripleComponentOrder.PSO);
+					Assert.assertTrue("can't find " + filePSO, Files.exists(filePSO));
+				} catch (Throwable t) {
+					try (Stream<Path> l = Files.list(fileName.getParent())) {
+						l.forEach(System.err::println);
+					} catch (Exception e) {
+						t.addSuppressed(e);
+					}
+					throw t;
+				}
+				return idx;
+			}
+		};
+		// endpoint.setThreshold(2);
+		return new SailRepository(endpoint);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+	}
+
+	HDT hdt;
+
+	private void setUpHDT(Dataset dataset) throws IOException, ParserException, NotFoundException {
+		if (dataset == null) {
+			return;
+		}
+
+		String x = dataset.getDefaultGraphs().toString();
+		if (x.equals("[]")) {
+			x = dataset.getNamedGraphs().toString();
+		}
+		String str = x.substring(x.lastIndexOf("!") + 1).replace("]", "");
+
+		URL url = SPARQL11QueryComplianceTest.class.getResource(str);
+		File tmpDir = new File("test");
+		if (tmpDir.mkdirs()) {
+			logger.debug("{} dir created.", tmpDir);
+		}
+		assert url != null;
+		JarURLConnection con = (JarURLConnection) url.openConnection();
+		File file = new File(tmpDir, con.getEntryName());
+
+		HDTOptions spec = HDTOptions.of();
+
+		hdt = HDTManager.generateHDT(file.getAbsolutePath(), "http://www.example.org/", RDFNotation.guess(file), spec,
+				null);
+		assert hdt != null;
+		hdt.search("", "", "").forEachRemaining(System.out::println);
+	}
+}

--- a/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/EndpointMultIndexSPARQL11UpdateComplianceTest.java
+++ b/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/EndpointMultIndexSPARQL11UpdateComplianceTest.java
@@ -1,0 +1,102 @@
+package com.the_qa_company.qendpoint.store;
+
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.triples.impl.BitmapTriplesIndex;
+import com.the_qa_company.qendpoint.core.triples.impl.BitmapTriplesIndexFile;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest.SPARQL11UpdateComplianceTest;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class EndpointMultIndexSPARQL11UpdateComplianceTest extends SPARQL11UpdateComplianceTest {
+
+	public EndpointMultIndexSPARQL11UpdateComplianceTest(String displayName, String testURI, String name,
+			String requestFile, IRI defaultGraphURI, Map<String, IRI> inputNamedGraphs, IRI resultDefaultGraphURI,
+			Map<String, IRI> resultNamedGraphs) {
+		super(displayName, testURI, name, requestFile, defaultGraphURI, inputNamedGraphs, resultDefaultGraphURI,
+				resultNamedGraphs);
+		List<String> testToIgnore = new ArrayList<>();
+		// @todo these tests are failing and should not, they are skipped so
+		// that we can be sure that we see when
+		// currently passing tests are not failing. Many of these tests are not
+		// so problematic since we do not support
+		// named graphs anyway
+		testToIgnore.add("DELETE INSERT 1b");
+		testToIgnore.add("DELETE INSERT 1c");
+		testToIgnore.add("CLEAR NAMED");
+		testToIgnore.add("DROP NAMED");
+		this.setIgnoredTests(testToIgnore);
+	}
+
+	@Rule
+	public TemporaryFolder tempDir = TemporaryFolder.builder().assureDeletion().build();
+
+	@Override
+	protected Repository newRepository() throws Exception {
+		File nativeStore = tempDir.newFolder();
+		File hdtStore = tempDir.newFolder();
+		HDTOptions spec = HDTOptions.of(HDTOptionsKeys.DICTIONARY_TYPE_KEY,
+				HDTOptionsKeys.DICTIONARY_TYPE_VALUE_MULTI_OBJECTS, HDTOptionsKeys.BITMAPTRIPLES_INDEX_OTHERS,
+				EnumSet.of(TripleComponentOrder.SPO, TripleComponentOrder.OPS, TripleComponentOrder.PSO));
+		Path fileName = Path.of(hdtStore.getAbsolutePath() + "/" + EndpointStoreTest.HDT_INDEX_NAME);
+		long size;
+		try (HDT hdt = Utility.createTempHdtIndex(tempDir, true, false, spec)) {
+			assert hdt != null;
+			size = hdt.getTriples().getNumberOfElements();
+			hdt.saveToHDT(fileName, null);
+		}
+
+		EndpointStore endpoint = new EndpointStore(hdtStore.getAbsolutePath() + "/", EndpointStoreTest.HDT_INDEX_NAME,
+				spec, nativeStore.getAbsolutePath() + "/", true) {
+
+			@Override
+			public HDT loadIndex() throws IOException {
+				HDT idx = super.loadIndex();
+				if (idx.getTriples().getNumberOfElements() == 0) {
+					return idx;
+				}
+				try {
+					Path fileOPS = BitmapTriplesIndexFile.getIndexPath(fileName, TripleComponentOrder.OPS);
+					Assert.assertTrue("can't find " + fileOPS, Files.exists(fileOPS));
+					Path filePSO = BitmapTriplesIndexFile.getIndexPath(fileName, TripleComponentOrder.PSO);
+					Assert.assertTrue("can't find " + filePSO, Files.exists(filePSO));
+				} catch (Throwable t) {
+					try (Stream<Path> l = Files.list(fileName.getParent())) {
+						l.forEach(System.err::println);
+					} catch (Exception e) {
+						t.addSuppressed(e);
+					}
+					throw t;
+				}
+				return idx;
+			}
+		};
+		// endpoint.setThreshold(2);
+
+		return new SailRepository(endpoint);
+		// return new DatasetRepository(new SailRepository(new
+		// NativeStore(tempDir.newFolder(), "spoc")));
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+	}
+}

--- a/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/MergeRestartTest.java
+++ b/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/MergeRestartTest.java
@@ -221,7 +221,6 @@ public class MergeRestartTest {
 			executeTestAddHDT(countFile, endpointStore, 4, count);
 
 			// show the bitmap and the file value
-			logger.debug("STEP1_TEST_BITMAP0o: {}", store.getDeleteBitMap().printInfo());
 			try (BitArrayDisk arr = new BitArrayDisk(0, hdtStore.getAbsolutePath() + "/triples-delete.arr")) {
 				logger.debug("STEP1_TEST_BITMAP0n: {}", arr.printInfo());
 			}
@@ -280,7 +279,6 @@ public class MergeRestartTest {
 				executeTestAddRDF(countFile, endpointStore, 4, count);
 				executeTestAddHDT(countFile, endpointStore, 4, count);
 
-				logger.debug("count of deleted in hdt step2s: " + store.getDeleteBitMap().countOnes());
 				// test if the count is correct
 				executeTestCount(countFile, endpointStore, store);
 				++step;
@@ -304,7 +302,6 @@ public class MergeRestartTest {
 				executeTestAddRDF(countFile, endpointStore, 4, count);
 				executeTestAddHDT(countFile, endpointStore, 4, count);
 
-				logger.debug("count of deleted in hdt step2e: " + store.getDeleteBitMap().countOnes());
 				// test if the count is correct
 				executeTestCount(countFile, endpointStore, store);
 				++step;
@@ -434,10 +431,6 @@ public class MergeRestartTest {
 
 		MergeRunnableStopPoint.STEP2_START.debugWaitForEvent();
 		if (point.ordinal() <= MergeRunnableStopPoint.STEP2_START.ordinal()) {
-			logger.debug("test count 0");
-			logger.debug("count of deleted in hdt: {}", store2.getDeleteBitMap().countOnes());
-			if (store2.getTempDeleteBitMap() != null)
-				logger.debug("count of tmp del in hdt: {}", store2.getTempDeleteBitMap().countOnes());
 			// test if the count is correct
 			executeTestCount(countFile, endpointStore2, store2);
 		}
@@ -445,10 +438,6 @@ public class MergeRestartTest {
 
 		MergeRunnableStopPoint.STEP2_END.debugWaitForEvent();
 		if (point.ordinal() <= MergeRunnableStopPoint.STEP2_END.ordinal()) {
-			logger.debug("test count 1");
-			logger.debug("count of deleted in hdt: {}", store2.getDeleteBitMap().countOnes());
-			if (store2.getTempDeleteBitMap() != null)
-				logger.debug("count of tmp del in hdt: {}", store2.getTempDeleteBitMap().countOnes());
 			// test if the count is correct
 			executeTestCount(countFile, endpointStore2, store2);
 		}
@@ -457,10 +446,6 @@ public class MergeRestartTest {
 		// wait for the merge to complete
 		MergeRunnable.debugWaitMerge();
 
-		logger.debug("test count 2");
-		logger.debug("count of deleted in hdt: {}", store2.getDeleteBitMap().countOnes());
-		if (store2.getTempDeleteBitMap() != null)
-			logger.debug("count of tmp del in hdt: {}", store2.getTempDeleteBitMap().countOnes());
 		// test if the count is correct
 		executeTestCount(countFile, endpointStore2, store2);
 	}
@@ -793,9 +778,6 @@ public class MergeRestartTest {
 		logger.debug("HDT: ");
 		while (it.hasNext()) {
 			logger.debug("- {}", it.next());
-		}
-		if (store != null) {
-			logger.debug("bitmap: {}", store.getDeleteBitMap().printInfo());
 		}
 	}
 

--- a/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/Utility.java
+++ b/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/store/Utility.java
@@ -90,7 +90,7 @@ public class Utility {
 		} catch (ParserException e) {
 			throw new IOException("Can't generate hdt", e);
 		}
-		return HDTManager.indexedHDT(hdt, null);
+		return HDTManager.indexedHDT(hdt, null, spec);
 	}
 
 	/**


### PR DESCRIPTION
Issue resolved (if any): #440

Description of this pull request:

Add delete bitmaps for the option `bitmaptriples.index.others`

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
