### PR TITLE
GH-455 Disable delete bitmap feature

### DIFF
--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStore.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStore.java
@@ -85,6 +85,10 @@ public class EndpointStore extends AbstractNotifyingSail {
 	 * enable the merge join, default true
 	 */
 	public static final String OPTION_QENDPOINT_MERGE_JOIN = "qendpoint.mergejoin";
+	/**
+	 * disable delete bitmaps, default false
+	 */
+	public static final String OPTION_QENDPOINT_DELETE_DISABLE = "qendpoint.delete.disable";
 	private static final AtomicLong ENDPOINT_DEBUG_ID_GEN = new AtomicLong();
 	private static final Logger logger = LoggerFactory.getLogger(EndpointStore.class);
 	private final long debugId;
@@ -113,6 +117,7 @@ public class EndpointStore extends AbstractNotifyingSail {
 	// setting to put the delete map only in memory, i.e don't write to disk
 	private final boolean inMemDeletes;
 	private final boolean loadIntoMemory;
+	private final boolean deleteDisabled;
 
 	// bitmaps used to mark if the subject, predicate, object elements in HDT
 	// are used in the rdf4j delta store
@@ -175,6 +180,7 @@ public class EndpointStore extends AbstractNotifyingSail {
 			throws IOException {
 		// load HDT file
 		this.spec = (spec = HDTOptions.ofNullable(spec));
+		deleteDisabled = spec.getBoolean(OPTION_QENDPOINT_DELETE_DISABLE, false);
 		validOrders = getHDTSpec().getEnumSet(HDTOptionsKeys.BITMAPTRIPLES_INDEX_OTHERS, TripleComponentOrder.class);
 		validOrders.add(TripleComponentOrder.SPO); // we need at least SPO
 
@@ -1213,6 +1219,10 @@ public class EndpointStore extends AbstractNotifyingSail {
 
 	public long getGraphsCount(HDT hdt) {
 		return hdt.getDictionary().supportGraphs() ? hdt.getDictionary().getNgraphs() : 1;
+	}
+
+	public boolean isDeleteDisabled() {
+		return deleteDisabled;
 	}
 
 	public long getGraphsCount() {

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreTripleIterator.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreTripleIterator.java
@@ -52,10 +52,16 @@ public class EndpointStoreTripleIterator implements CloseableIteration<Statement
 		// iterate over the result of hdt
 		while (iterator.hasNext()) {
 			TripleID tripleID = iterator.next();
-			long index = iterator.getLastTriplePosition();
+			long index;
+			if (endpoint.isDeleteDisabled()) {
+				index = -1;
+			} else {
+				index = iterator.getLastTriplePosition();
+			}
 			TripleComponentOrder order = iterator.isLastTriplePositionBoundToOrder() ? iterator.getOrder()
 					: TripleComponentOrder.SPO;
-			if (!endpoint.getDeleteBitMap(order).access(tripleID.isQuad() ? tripleID.getGraph() - 1 : 0, index)) {
+			if (endpoint.isDeleteDisabled() || !endpoint.getDeleteBitMap(order)
+					.access(tripleID.isQuad() ? tripleID.getGraph() - 1 : 0, index)) {
 				Resource subject = endpoint.getHdtConverter().idToSubjectHDTResource(tripleID.getSubject());
 				IRI predicate = endpoint.getHdtConverter().idToPredicateHDTResource(tripleID.getPredicate());
 				Value object = endpoint.getHdtConverter().idToObjectHDTResource(tripleID.getObject());


### PR DESCRIPTION
Issue resolved (if any): #455 

Description of this pull request:

Add the option `qendpoint.delete.disable` to disable the deletes in the qendpoint.

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
