### PR TITLE
GH-455 Disable delete bitmap when not required

### DIFF
--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreTripleIterator.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/store/EndpointStoreTripleIterator.java
@@ -1,7 +1,9 @@
 package com.the_qa_company.qendpoint.store;
 
+import com.the_qa_company.qendpoint.core.compact.bitmap.MultiLayerBitmapWrapper;
 import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.store.exception.EndpointTimeoutException;
+import com.the_qa_company.qendpoint.utils.BitArrayDisk;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.IndexReportingIterator;
 import org.eclipse.rdf4j.model.IRI;
@@ -52,16 +54,11 @@ public class EndpointStoreTripleIterator implements CloseableIteration<Statement
 		// iterate over the result of hdt
 		while (iterator.hasNext()) {
 			TripleID tripleID = iterator.next();
-			long index;
-			if (endpoint.isDeleteDisabled()) {
-				index = -1;
-			} else {
-				index = iterator.getLastTriplePosition();
-			}
 			TripleComponentOrder order = iterator.isLastTriplePositionBoundToOrder() ? iterator.getOrder()
 					: TripleComponentOrder.SPO;
-			if (endpoint.isDeleteDisabled() || !endpoint.getDeleteBitMap(order)
-					.access(tripleID.isQuad() ? tripleID.getGraph() - 1 : 0, index)) {
+			MultiLayerBitmapWrapper.MultiLayerModBitmapWrapper dbm = endpoint.getDeleteBitMap(order);
+			if (endpoint.isDeleteDisabled() || dbm.<BitArrayDisk>getHandle().getMaxNumBits() == 0
+					|| !dbm.access(tripleID.isQuad() ? tripleID.getGraph() - 1 : 0, iterator.getLastTriplePosition())) {
 				Resource subject = endpoint.getHdtConverter().idToSubjectHDTResource(tripleID.getSubject());
 				IRI predicate = endpoint.getHdtConverter().idToPredicateHDTResource(tripleID.getPredicate());
 				Value object = endpoint.getHdtConverter().idToObjectHDTResource(tripleID.getObject());

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/utils/BitArrayDisk.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/utils/BitArrayDisk.java
@@ -404,4 +404,11 @@ public class BitArrayDisk implements ModifiableBitmap, Closeable {
 				+ (inMemory ? ", inMemory: true" : "\nfile: " + output.getFile().getAbsolutePath())
 				+ (allBits <= 20 ? "\nbits: " + toString(true) : "");
 	}
+
+	/**
+	 * @return the maximum bit of this bitmap
+	 */
+	public long getMaxNumBits() {
+		return numbits;
+	}
 }


### PR DESCRIPTION
Issue resolved (if any): #455 

Description of this pull request:

Remove the need to add the option added in #446 when it is not required.

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
