### PR TITLE
GH-458 Regenerate index if signature is wrong

### DIFF
--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/exceptions/SignatureIOException.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/exceptions/SignatureIOException.java
@@ -1,0 +1,20 @@
+package com.the_qa_company.qendpoint.core.exceptions;
+
+import java.io.IOException;
+
+public class SignatureIOException extends IOException {
+	public SignatureIOException() {
+	}
+
+	public SignatureIOException(String message) {
+		super(message);
+	}
+
+	public SignatureIOException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SignatureIOException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriples.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriples.java
@@ -33,6 +33,7 @@ import com.the_qa_company.qendpoint.core.compact.sequence.SequenceLog64BigDisk;
 import com.the_qa_company.qendpoint.core.dictionary.Dictionary;
 import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.core.exceptions.IllegalFormatException;
+import com.the_qa_company.qendpoint.core.exceptions.SignatureIOException;
 import com.the_qa_company.qendpoint.core.hdt.HDTVocabulary;
 import com.the_qa_company.qendpoint.core.hdt.impl.HDTDiskImporter;
 import com.the_qa_company.qendpoint.core.hdt.impl.diskindex.DiskIndexSort;
@@ -1347,7 +1348,7 @@ public class BitmapTriples implements TriplesPrivate, BitmapTriplesIndex {
 							idx.getOrder());
 				}
 				IOUtil.closeQuietly(old);
-			} catch (NoSuchFileException ignore) {
+			} catch (NoSuchFileException | SignatureIOException ignore) {
 				// no index with this name
 				if (!askedOrders.contains(order)) {
 					continue; // not asked by the user, we can ignore

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriplesIndexFile.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriplesIndexFile.java
@@ -11,6 +11,7 @@ import com.the_qa_company.qendpoint.core.compact.sequence.SequenceFactory;
 import com.the_qa_company.qendpoint.core.compact.sequence.SequenceLog64BigDisk;
 import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.core.exceptions.IllegalFormatException;
+import com.the_qa_company.qendpoint.core.exceptions.SignatureIOException;
 import com.the_qa_company.qendpoint.core.iterator.utils.AsyncIteratorFetcher;
 import com.the_qa_company.qendpoint.core.iterator.utils.ExceptionIterator;
 import com.the_qa_company.qendpoint.core.iterator.utils.MapIterator;
@@ -96,7 +97,8 @@ public class BitmapTriplesIndexFile implements BitmapTriplesIndex, Closeable {
 
 			long currentSignature = signature(triples);
 			if (signature != currentSignature) {
-				throw new IOException(format("Wrong signature for file 0x%x != 0x%x", signature, currentSignature));
+				throw new SignatureIOException(
+						format("Wrong signature for file 0x%x != 0x%x", signature, currentSignature));
 			}
 		}
 

--- a/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriplesIndexFileTest.java
+++ b/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriplesIndexFileTest.java
@@ -1,0 +1,74 @@
+package com.the_qa_company.qendpoint.core.triples.impl;
+
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
+import com.the_qa_company.qendpoint.core.exceptions.ParserException;
+import com.the_qa_company.qendpoint.core.hdt.HDTManager;
+import com.the_qa_company.qendpoint.core.hdt.HDTVersion;
+import com.the_qa_company.qendpoint.core.listener.ProgressListener;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.util.LargeFakeDataSetStreamSupplier;
+import com.the_qa_company.qendpoint.core.util.crc.CRC32;
+import org.apache.commons.io.file.PathUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class BitmapTriplesIndexFileTest {
+
+	@Rule
+	public TemporaryFolder tempDir = TemporaryFolder.builder().assureDeletion().build();
+
+	public long crc32(byte[] data) {
+		CRC32 crc = new CRC32();
+		crc.update(data, 0, data.length);
+		return crc.getValue();
+	}
+
+	@Test
+	public void genTest() throws IOException, ParserException {
+		Path root = tempDir.newFolder().toPath();
+
+		HDTOptions spec = HDTOptions.of(
+				HDTOptionsKeys.BITMAPTRIPLES_INDEX_OTHERS, "spo,ops",
+				HDTOptionsKeys.BITMAPTRIPLES_INDEX_NO_FOQ, true
+		);
+		try {
+			Path hdtPath = root.resolve("temp.hdt");
+
+			LargeFakeDataSetStreamSupplier supplier = LargeFakeDataSetStreamSupplier
+					.createSupplierWithMaxTriples(1000, 10)
+					.withMaxLiteralSize(50)
+					.withMaxElementSplit(20);
+
+			supplier.createAndSaveFakeHDT(spec, hdtPath);
+
+			// should load
+			HDTManager.mapIndexedHDT(hdtPath, spec, ProgressListener.ignore()).close();
+			assertTrue("ops index doesn't exist", Files.exists(BitmapTriplesIndexFile.getIndexPath(hdtPath, TripleComponentOrder.OPS)));
+			assertFalse("foq index exists", Files.exists(hdtPath.resolveSibling(hdtPath.getFileName() + HDTVersion.get_index_suffix("-"))));
+
+			long crcold = crc32(Files.readAllBytes(hdtPath));
+
+			Path hdtPath2 = root.resolve("temp2.hdt");
+
+			Files.move(hdtPath, hdtPath2);
+
+			supplier.createAndSaveFakeHDT(spec, hdtPath);
+			// should erase the previous index and generate another one
+			HDTManager.mapIndexedHDT(hdtPath, spec, ProgressListener.ignore()).close();
+
+			long crcnew = crc32(Files.readAllBytes(hdtPath));
+
+			assertNotEquals("files are the same", crcold, crcnew);
+		} finally {
+			PathUtils.deleteDirectory(root);
+		}
+	}
+}


### PR DESCRIPTION
Issue resolved (if any): #458 

Description of this pull request:

Regenerate the other indexes if the signature is wrong

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
