### PR TITLE
GH-460 prof to csv

### DIFF
--- a/qendpoint-cli/bin/qepSearch.ps1
+++ b/qendpoint-cli/bin/qepSearch.ps1
@@ -5,6 +5,8 @@ param(
     $config,
     [String]
     $searchCfg,
+    [String]
+    $csv,
     [Switch]
     $color,
     [Parameter()]

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/tools/QEPSearch.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/tools/QEPSearch.java
@@ -47,17 +47,20 @@ import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSail;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -90,6 +93,9 @@ public class QEPSearch {
 
 	@Parameter(names = "-rdf4jindex", description = "RDF4J indexes, default spoc,posc,cosp")
 	public String rdf4jindex;
+
+	@Parameter(names = "-csv", description = "Dump with a CSV form if available")
+	public String csvDump;
 
 	@Parameter(names = "-version", description = "Prints the HDT version number")
 	public static boolean showVersion;
@@ -710,19 +716,13 @@ public class QEPSearch {
 					}
 
 					switch (opt) {
-					case "delta" -> {
-						integrityTest(ep);
-					}
-					case "hdt" -> {
-						integrityTest(ep.getHdt());
-					}
+					case "delta" -> integrityTest(ep);
+					case "hdt" -> integrityTest(ep.getHdt());
 					case "all" -> {
 						integrityTest(ep);
 						integrityTest(ep.getHdt());
 					}
-					default -> {
-						colorTool.print(colorTool.red() + "integrity (delta|hdt|all)");
-					}
+					default -> colorTool.print(colorTool.red() + "integrity (delta|hdt|all)");
 					}
 					continue;
 
@@ -924,10 +924,85 @@ public class QEPSearch {
 		}
 	}
 
+	private static int findProfilerMaxDepth(Profiler.Section sec, int currentDepth) {
+		return sec.getSubSections().stream().mapToInt(sub -> findProfilerMaxDepth(sub, currentDepth + 1)).max()
+				.orElse(currentDepth);
+	}
+
+	private static int findProfilerMaxDepth(Profiler p) {
+		return findProfilerMaxDepth(p.getMainSection(), 0);
+	}
+
+	record NamedSection(String name, Profiler.Section sec) {}
+
+	private static void findProfilerPatterns(Profiler.Section prof, Map<String, List<NamedSection>> patterns, int depth,
+			String name) {
+		String kname = name.isEmpty() ? prof.getName() : (name + "/" + prof.getName());
+		List<Profiler.Section> subs = prof.getSubSections();
+
+		if (subs.isEmpty()) {
+			return; // we hit a leaf, useless
+		}
+
+		if (depth == 0) {
+			String key = subs.stream().map(Profiler.Section::getName).sorted().collect(Collectors.joining(","));
+
+			patterns.computeIfAbsent(key, k -> new ArrayList<>()).add(new NamedSection(kname, prof));
+			return;
+		}
+
+		subs.forEach(ss -> findProfilerPatterns(ss, patterns, depth - 1, kname));
+	}
+
 	private void executeProfiler() throws IOException {
 		try (Profiler p = Profiler.readFromDisk(Path.of(input))) {
 			p.setDisabled(false);
-			p.writeProfiling();
+			if (csvDump == null) {
+				p.writeProfiling();
+				return;
+			}
+			int maxDepth = findProfilerMaxDepth(p);
+
+			Path csvDir = Path.of(csvDump);
+			Files.createDirectories(csvDir);
+
+			Map<String, List<NamedSection>> patterns = new HashMap<>();
+			for (int layer = 0; layer < maxDepth; layer++) {
+				patterns.clear();
+				findProfilerPatterns(p.getMainSection(), patterns, layer, "");
+
+				Path loc = csvDir.resolve("depth-" + layer);
+
+				Files.createDirectories(loc);
+
+				int id = 0;
+				for (List<NamedSection> secs : patterns.values()) {
+					if (secs.isEmpty()) {
+						System.err.println("Find empty pattern, bad code?");
+						continue; // what?
+					}
+					Path profCsv = loc.resolve("prof-" + (id++) + ".csv");
+					try (BufferedWriter writer = Files.newBufferedWriter(profCsv)) {
+						NamedSection sec = secs.get(0);
+
+						List<Profiler.Section> subs = sec.sec().getSubSections();
+
+						writer.write(subs.stream().map(Profiler.Section::getName).sorted()
+								.collect(Collectors.joining(",", "name,", "")));
+
+						for (NamedSection ns : secs) {
+							writer.write("\n");
+							writer.write(ns.name());
+
+							writer.write(ns.sec.getSubSections().stream()
+									.sorted(Comparator.comparing(Profiler.Section::getName))
+									.map(nss -> "," + nss.getMillis()).collect(Collectors.joining()));
+						}
+						writer.flush();
+					}
+					System.out.println("Generated " + profCsv);
+				}
+			}
 		}
 	}
 
@@ -957,9 +1032,7 @@ public class QEPSearch {
 						colorTool.log("bye.");
 						return;
 					}
-					case "pwd" -> {
-						System.out.println(pwd);
-					}
+					case "pwd" -> System.out.println(pwd);
 					case "ls" -> {
 						try (Stream<Path> list = Files.list(pwd)) {
 							System.out.println("File for " + pwd);
@@ -1052,10 +1125,8 @@ public class QEPSearch {
 						case "?" -> {
 							if (obj instanceof LongArray la) {
 								colorTool.log(format("[array$%d] %s [close]|[id]", la.sizeOf(), args[0]));
-								continue;
 							} else if (obj instanceof Bitmap) {
 								colorTool.log(format("[bitmap] %s [close]|[id]", args[0]));
-								continue;
 							} else {
 								colorTool.error("unknown type: " + obj.getClass());
 							}


### PR DESCRIPTION
Issue resolved (if any): #460 

Description of this pull request:

Add -csv option to qepsearch to dump profiler into csv files.

It'll group the section with the same element names and depth. Example for a rdf2hdt cat generation:

```
depth-0/prof-0.csv
depth-1/prof-0.csv
depth-1/prof-1.csv
depth-2/prof-0.csv
depth-2/prof-1.csv
```

Usage:

```pwsh
qepSearch [input] -csv [output_dir]
```

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
