### PR TITLE
GH-482 Auto indexer

### DIFF
--- a/qendpoint-cli/bin/indexhdtrepo.bat
+++ b/qendpoint-cli/bin/indexhdtrepo.bat
@@ -1,0 +1,5 @@
+@echo off
+
+call "%~dp0\javaenv.bat"
+
+"%JAVACMD%" %JAVAOPTIONS% -classpath %~dp0\..\lib\* com.the_qa_company.qendpoint.core.tools.HDTAutoIndexer %*

--- a/qendpoint-cli/bin/indexhdtrepo.ps1
+++ b/qendpoint-cli/bin/indexhdtrepo.ps1
@@ -1,0 +1,21 @@
+param(
+    [Parameter()]
+    [String]
+    $options,
+    [Parameter()]
+    [String]
+    $config,
+    [Parameter()]
+    [Switch]
+    $color,
+    [Parameter()]
+    [Switch]
+    $quiet,
+    [string]
+    $base,
+    [Parameter(ValueFromRemainingArguments, Position = 0)]
+    [string[]]
+    $OtherParams
+)
+
+& "$(Get-Item $PSScriptRoot)/javaenv.ps1" "com.the_qa_company.qendpoint.core.tools.HDTAutoIndexer" -RequiredParameters $PSBoundParameters

--- a/qendpoint-cli/bin/indexhdtrepo.sh
+++ b/qendpoint-cli/bin/indexhdtrepo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source `dirname $0`/javaenv.sh
+
+$JAVA $JAVA_OPTIONS -cp $CP:$CLASSPATH com.the_qa_company.qendpoint.core.tools.HDTAutoIndexer $*
+
+exit $?

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/exceptions/SameChecksumException.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/exceptions/SameChecksumException.java
@@ -1,0 +1,5 @@
+package com.the_qa_company.qendpoint.core.exceptions;
+
+public class SameChecksumException extends RuntimeException {
+
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptionsKeys.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptionsKeys.java
@@ -543,6 +543,21 @@ public class HDTOptionsKeys {
 	@Key(type = Key.Type.NUMBER, desc = "Predownload url retry count, 0 for infinite, default to 1")
 	public static final String LOADER_PREDOWNLOAD_URL_RETRY = "loader.predownloadURL.retry";
 
+	@Key(type = Key.Type.PATH, desc = "Predownload url checksum location, defalt none")
+	public static final String LOADER_PREDOWNLOAD_CHECKSUM_PATH = "loader.predownloadURL.checksum.path";
+
+	@Key(type = Key.Type.BOOLEAN, desc = "fail if the checksum is set and is the same as the previous one using SameChecksumException")
+	public static final String LOADER_PREDOWNLOAD_CHECKSUM_FAIL_SAME = "loader.predownloadURL.checksum.failSame";
+
+	@Key(type = Key.Type.NUMBER, desc = "describe the amount of time between each generation in ms, default 10000")
+	public static final String AUTOINDEXER_SLEEP_TIME_MILLIS = "autoIndexer.sleepTimeMillis";
+
+	@Key(type = Key.Type.STRING, desc = "describe the name of the index, default: index_dev")
+	public static final String AUTOINDEXER_INDEX_NAME = "autoIndexer.indexName";
+
+	@Key(type = Key.Type.BOOLEAN, desc = "only run the remote path in the autoexec, default: true")
+	public static final String AUTOINDEXER_RUN_ONLY_REMOTE = "autoIndexer.runOnlyRemove";
+
 	// use tree-map to have a better order
 	private static final Map<String, Option> OPTION_MAP = new TreeMap<>();
 

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/tools/HDTAutoIndexer.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/tools/HDTAutoIndexer.java
@@ -1,0 +1,171 @@
+package com.the_qa_company.qendpoint.core.tools;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.the_qa_company.qendpoint.core.enums.RDFNotation;
+import com.the_qa_company.qendpoint.core.exceptions.SameChecksumException;
+import com.the_qa_company.qendpoint.core.hdt.HDT;
+import com.the_qa_company.qendpoint.core.hdt.HDTManager;
+import com.the_qa_company.qendpoint.core.options.HDTOptions;
+import com.the_qa_company.qendpoint.core.options.HDTOptionsKeys;
+import com.the_qa_company.qendpoint.core.util.StopWatch;
+import com.the_qa_company.qendpoint.core.util.io.IOUtil;
+import com.the_qa_company.qendpoint.core.util.listener.ColorTool;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class HDTAutoIndexer {
+	private ColorTool colorTool;
+
+	@Parameter(description = "<url/path> <output>")
+	public List<String> parameters = new ArrayList<>();
+
+	@Parameter(names = "-options", description = "HDT Conversion options (override those of config file)")
+	public String options;
+
+	@Parameter(names = "-config", description = "Conversion config file")
+	public String configFile;
+
+	@Parameter(names = "-index", description = "Generate also external indices to solve all queries")
+	public boolean generateIndex;
+
+	@Parameter(names = "-color", description = "Print using color (if available)")
+	public boolean color;
+
+	@Parameter(names = "-quiet", description = "Do not show progress of the conversion")
+	public boolean quiet;
+
+	@Parameter(names = "-base", description = "Base URI for the dataset")
+	public String baseURI;
+
+	public void execute() throws IOException, InterruptedException {
+		HDTOptions cfg;
+		if (configFile != null) {
+			cfg = HDTOptions.readFromFile(configFile);
+		} else {
+			cfg = HDTOptions.of();
+		}
+		if (options != null) {
+			cfg.setOptions(options);
+		}
+
+		String path = parameters.get(0);
+		Path output = Path.of(parameters.get(1));
+
+		if (baseURI == null) {
+			String input = path.toLowerCase();
+			if (input.startsWith("http") || input.startsWith("ftp")) {
+				baseURI = URI.create(path).toString();
+			} else {
+				baseURI = Path.of(path).toUri().toString();
+			}
+			colorTool.warn("base uri not specified, using '" + baseURI + "'");
+		}
+
+		boolean one = !IOUtil.isRemoteURL(path) && cfg.getBoolean(HDTOptionsKeys.AUTOINDEXER_RUN_ONLY_REMOTE, true);
+		colorTool.warn("The path is local, only one iteration will be performed, use "
+				+ HDTOptionsKeys.AUTOINDEXER_RUN_ONLY_REMOTE + "=false to index it");
+
+		HDTOptions spec = cfg.pushBottom();
+		Path outTmpDir = output.resolve("tmp_output");
+		Path checksumFile = outTmpDir.resolve("checksum");
+		Path realChecksumFile = output.resolve("checksum");
+		spec.setOptions(
+				// predownload
+				HDTOptionsKeys.LOADER_PREDOWNLOAD_URL, true,
+				// temp file
+				HDTOptionsKeys.LOADER_PREDOWNLOAD_URL_FILE, output.resolve("temp_dl" + IOUtil.getSuffix(path)),
+				// checksum
+				HDTOptionsKeys.LOADER_PREDOWNLOAD_CHECKSUM_PATH, checksumFile,
+				// read checksum
+				HDTOptionsKeys.LOADER_PREDOWNLOAD_CHECKSUM_FAIL_SAME, true);
+		long sleepTime = spec.getInt(HDTOptionsKeys.AUTOINDEXER_SLEEP_TIME_MILLIS, 10_000);
+		String hdtName = spec.get(HDTOptionsKeys.AUTOINDEXER_INDEX_NAME, "index_dev") + ".hdt";
+		Path endIndex = output.resolve(hdtName);
+		Path tmpIndex = outTmpDir.resolve(hdtName);
+		Files.createDirectories(output);
+
+		long currentId = 0;
+		while (true) {
+			StopWatch sw = new StopWatch();
+			currentId++;
+			colorTool.log("start iteration #" + currentId);
+			colorTool.log("Cleaning old directory...");
+			IOUtil.deleteDirRecurse(outTmpDir);
+			Files.createDirectories(outTmpDir);
+			if (!Files.exists(endIndex)) {
+				colorTool.warn("No end hdt, deleting checksum file...");
+				Files.deleteIfExists(realChecksumFile);
+			} else if (Files.exists(realChecksumFile)) {
+				Files.copy(realChecksumFile, checksumFile);
+			}
+
+			try {
+				StopWatch sw2 = new StopWatch();
+				try (HDT hdt = HDTManager.generateHDT(path, baseURI, RDFNotation.guess(path), spec,
+						colorTool.getConsole())) {
+					Files.createDirectories(tmpIndex.getParent());
+					hdt.saveToHDT(tmpIndex);
+					colorTool.log("HDT generated and saved in " + sw2.stopAndShow());
+
+					sw2.reset();
+					HDTManager.indexedHDT(hdt, colorTool.getConsole(), spec).close();
+					colorTool.log("HDT indexes in " + sw2.stopAndShow());
+				}
+
+				try (Stream<Path> list = Files.list(outTmpDir)) {
+					Iterator<Path> it = list.iterator();
+
+					sw2.reset();
+					while (it.hasNext()) {
+						Path newFile = it.next();
+						Path real = output.resolve(newFile.getFileName());
+
+						colorTool.log("Moving " + newFile + " -> " + real);
+						Files.move(newFile, real, StandardCopyOption.REPLACE_EXISTING);
+					}
+					colorTool.log("Moving done in " + sw2.stopAndShow());
+				}
+			} catch (SameChecksumException e) {
+				colorTool.warn("Find the same checksum as the previous dataset, generation canceled");
+			} catch (Exception e) {
+				colorTool.error("Exception when running the tool");
+				e.printStackTrace();
+				System.err.println();
+			}
+			colorTool.log("iteration #" + currentId + " took " + sw.stopAndShow());
+			IOUtil.deleteDirRecurse(outTmpDir);
+			if (one) {
+				colorTool.log("The path is local, no more iterations");
+				break;
+			}
+			if (sleepTime > 0) {
+				Thread.sleep(sleepTime);
+			}
+
+		}
+	}
+
+	public static void main(String[] args) throws Throwable {
+		HDTAutoIndexer indexhdtrepo = new HDTAutoIndexer();
+		JCommander com = new JCommander(indexhdtrepo);
+		com.parse(args);
+		com.setProgramName("indexhdtrepo");
+		indexhdtrepo.colorTool = new ColorTool(indexhdtrepo.color, indexhdtrepo.quiet);
+
+		if (indexhdtrepo.parameters.size() < 2) {
+			com.usage();
+			return;
+		}
+
+		indexhdtrepo.execute();
+	}
+}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/StringUtil.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/StringUtil.java
@@ -76,9 +76,9 @@ public class StringUtil {
 	public static int lastIndexOf(String chars, String string) {
 		int max = -1;
 		for (int i = 0; i < chars.length(); i++) {
-			int idx = string.lastIndexOf(chars.charAt(i), max + 1);
+			int idx = string.lastIndexOf(chars.charAt(i));
 
-			if (idx != -1) {
+			if (idx > max) {
 				max = idx;
 			}
 		}

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/crc/CRCInputStream.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/crc/CRCInputStream.java
@@ -63,6 +63,8 @@ public class CRCInputStream extends FilterInputStream {
 	@Override
 	public int read(byte[] b, int off, int len) throws IOException {
 		int ret = in.read(b, off, len);
+		if (ret == -1)
+			return -1;
 		crc.update(b, off, ret);
 		return ret;
 	}

--- a/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/util/StringUtilTest.java
+++ b/qendpoint-core/src/test/java/com/the_qa_company/qendpoint/core/util/StringUtilTest.java
@@ -1,0 +1,18 @@
+package com.the_qa_company.qendpoint.core.util;
+
+import com.the_qa_company.qendpoint.core.util.io.IOUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StringUtilTest {
+
+	@Test
+	public void suffixTest() {
+		String str = "/test:t:.txt";
+		assertEquals(".txt", str.substring(StringUtil.lastIndexOf("/!:", str) + 1));
+		assertEquals(".txt", IOUtil.getSuffix(str));
+
+	}
+}


### PR DESCRIPTION
Issue resolved (if any): #482 

Description of this pull request:

Add tool to loop a generation, same options as the rdf2hdt, in takes in param the path and then the path to download it, it has 3 options in the specs:

- `autoIndexer.sleepTimeMillis`: Time between each generation in millis (default 10s)
- `autoIndexer.indexName`: The name of the index without the ".hdt", (default "index_dev")
- `autoIndexer.runOnlyRemove`: Do not run in loop local files (default true)

**Example**
```pwsh
indexhdtrepo.ps1 https://data.wikibase.the-qa-company.com/dump_latest.ttl wikibase -config option.spec
```

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
