### PR TITLE
GH-486 Add option to read v0 indexes

### DIFF
--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptionsKeys.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/options/HDTOptionsKeys.java
@@ -528,6 +528,9 @@ public class HDTOptionsKeys {
 	@Key(type = Key.Type.STRING, desc = "Create other indexes in bitmaptriples pattern values (spo, ops, etc.), default none")
 	public static final String BITMAPTRIPLES_INDEX_OTHERS = "bitmaptriples.index.others";
 
+	@Key(type = Key.Type.BOOLEAN, desc = "Allow old other indexes, default false")
+	public static final String BITMAPTRIPLES_INDEX_ALLOW_OLD_OTHERS = "bitmaptriples.index.allowOldOthers";
+
 	@Key(type = Key.Type.BOOLEAN, desc = "No FoQ index generation default false")
 	public static final String BITMAPTRIPLES_INDEX_NO_FOQ = "bitmaptriples.index.noFoQ";
 

--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriples.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/triples/impl/BitmapTriples.java
@@ -1316,6 +1316,7 @@ public class BitmapTriples implements TriplesPrivate, BitmapTriplesIndex {
 		}
 
 		String otherIdxs = spec.get(HDTOptionsKeys.BITMAPTRIPLES_INDEX_OTHERS, "");
+		boolean allowOldOthers = spec.getBoolean(HDTOptionsKeys.BITMAPTRIPLES_INDEX_ALLOW_OLD_OTHERS, false);
 
 		Set<TripleComponentOrder> askedOrders = Arrays.stream(otherIdxs.toUpperCase().split(",")).map(e -> {
 			if (e.isEmpty() || e.equalsIgnoreCase(TripleComponentOrder.Unknown.name())) {
@@ -1340,7 +1341,7 @@ public class BitmapTriples implements TriplesPrivate, BitmapTriplesIndex {
 			try (FileChannel channel = FileChannel.open(subIndexPath, StandardOpenOption.READ)) {
 				// load from the path...
 
-				BitmapTriplesIndex idx = BitmapTriplesIndexFile.map(subIndexPath, channel, this);
+				BitmapTriplesIndex idx = BitmapTriplesIndexFile.map(subIndexPath, channel, this, allowOldOthers);
 				BitmapTriplesIndex old = indexes.put(order, idx);
 				indexesMask |= idx.getOrder().mask;
 				if (old != null) {
@@ -1357,7 +1358,7 @@ public class BitmapTriples implements TriplesPrivate, BitmapTriplesIndex {
 				BitmapTriplesIndexFile.generateIndex(this, subIndexPath, order, spec, mListener);
 				try (FileChannel channel = FileChannel.open(subIndexPath, StandardOpenOption.READ)) {
 					// load from the path...
-					BitmapTriplesIndex idx = BitmapTriplesIndexFile.map(subIndexPath, channel, this);
+					BitmapTriplesIndex idx = BitmapTriplesIndexFile.map(subIndexPath, channel, this, allowOldOthers);
 					BitmapTriplesIndex old = indexes.put(order, idx);
 					indexesMask |= order.mask;
 					if (old != null) {


### PR DESCRIPTION
Issue resolved (if any): #486 

Description of this pull request:

Add option `bitmaptriples.index.allowOldOthers` with a default false to read v0 indexes

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
