### PR TITLE
GH-489 delete bitmap reload issue

### DIFF
--- a/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
+++ b/qendpoint-backend/src/main/java/com/the_qa_company/qendpoint/controller/Sparql.java
@@ -6,6 +6,7 @@ import com.the_qa_company.qendpoint.compiler.CompiledSail;
 import com.the_qa_company.qendpoint.compiler.CompiledSailOptions;
 import com.the_qa_company.qendpoint.compiler.SailCompilerSchema;
 import com.the_qa_company.qendpoint.compiler.SparqlRepository;
+import com.the_qa_company.qendpoint.core.enums.TripleComponentOrder;
 import com.the_qa_company.qendpoint.store.EndpointFiles;
 import com.the_qa_company.qendpoint.store.EndpointStore;
 import com.the_qa_company.qendpoint.store.EndpointStoreUtils;
@@ -499,6 +500,14 @@ public class Sparql {
 					}
 
 					Files.move(endHDT, endIndex);
+
+					// delete the old bitmap
+					Files.deleteIfExists(Path.of(files.getHDTBitX()));
+					Files.deleteIfExists(Path.of(files.getHDTBitY()));
+					Files.deleteIfExists(Path.of(files.getHDTBitZ()));
+					for (TripleComponentOrder order : TripleComponentOrder.values()) {
+						Files.deleteIfExists(Path.of(files.getTripleDeleteArr(order)));
+					}
 				} finally {
 					if (Files.exists(endIndex)) {
 						// everything worked


### PR DESCRIPTION
Issue resolved (if any): #489 

Description of this pull request:

When a dataset is loaded, we delete the old delete bitmap(s) and the bit bitmaps

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
