### PR TITLE
README.md: make "PDF" links point to actual PDF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,10 +412,10 @@ _For more information and to report security issues, please refer to our [securi
 
 ## Publications
 
-- Willerval Antoine, Dennis Diefenbach, and Pierre Maret. "Easily setting up a local Wikidata SPARQL endpoint using the qEndpoint." Workshop ISWC (2022). [PDF](https://www.researchgate.net/publication/364321138_Easily_setting_up_a_local_Wikidata_SPARQL_endpoint_using_the_qEndpoint)
-- Willerval Antoine, Dennis Diefenbach, Angela Bonifati. "qEndpoint: A Wikidata SPARQL endpoint on commodity hardware" Demo at The Web Conference (2023).  [PDF](https://www.researchgate.net/publication/369693531_qEndpoint_A_Wikidata_SPARQL_endpoint_on_commodity_hardware)
-- Willerval Antoine, Dennis Diefenbach, Angela Bonifati. "qEndpoint: A Novel Triple Store Architecture for Large RDF Graphs" Semantic Web Journal (2024). [PDF](https://www.researchgate.net/publication/379507680_qEndpoint_A_Novel_Triple_Store_Architecture_for_Large_RDF_Graphs)
-- Willerval Antoine, Dennis Diefenbach, Angela Bonifati. "Generate and Update Large HDT RDF Knowledge Graphs on Commodity Hardware" ESWC (2024). [PDF](https://www.researchgate.net/publication/379507028_Generate_and_Update_Large_HDT_RDF_Knowledge_Graphs_on_Commodity_Hardware)
+- Willerval Antoine, Dennis Diefenbach, and Pierre Maret. "Easily setting up a local Wikidata SPARQL endpoint using the qEndpoint." Workshop ISWC (2022). [PDF](https://ceur-ws.org/Vol-3262/paper10.pdf)
+- Willerval Antoine, Dennis Diefenbach, Angela Bonifati. "qEndpoint: A Wikidata SPARQL endpoint on commodity hardware" Demo at The Web Conference (2023).  [PDF](https://hal.science/hal-04370881/document)
+- Willerval Antoine, Dennis Diefenbach, Angela Bonifati. "qEndpoint: A Novel Triple Store Architecture for Large RDF Graphs" Semantic Web Journal (2024). [PDF](https://www.semantic-web-journal.net/system/files/swj3616.pdf)
+- Willerval Antoine, Dennis Diefenbach, Angela Bonifati. "Generate and Update Large HDT RDF Knowledge Graphs on Commodity Hardware" ESWC (2024). (closed-access publication)
 
 ---
 


### PR DESCRIPTION
The "PDF" links to the publications about qEndpoint currently link to landing pages on ResearchGate, which do not always have a PDF to offer, so I think that's a bit misleading.

As a courtesy to readers, I propose to give direct links to PDF files. This PR does that for the first three publications mentioned.

Sadly I could not find an open access version of the last publication, so I would encourage the authors to upload a postprint (author manuscript after integration of the reviewers' comments) to an open archive such as arXiv or HAL, and add the link to the README.

For an introduction to the problem of publicly funded research ending up behind paywalls and a summary of the open access movement, I recommend [this PhD comics video](https://www.youtube.com/watch?v=L5rVH1KGBCY).