### PR TITLE
GH-485 Add Lucene Threshold and update to rdf4j 5.1.0

### DIFF
--- a/qendpoint-store/pom.xml
+++ b/qendpoint-store/pom.xml
@@ -41,7 +41,7 @@
         <json_simple.version>1.1.1</json_simple.version>
         <junit.version>4.13.2</junit.version>
         <lwjgl.version>3.3.1</lwjgl.version>
-        <rdf4j.version>5.0.2</rdf4j.version>
+        <rdf4j.version>5.1.0</rdf4j.version>
         <logback.version>1.4.5</logback.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SailCompiler.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SailCompiler.java
@@ -439,6 +439,22 @@ public class SailCompiler {
 		}
 
 		/**
+		 * search for an optional property value in the graph
+		 *
+		 * @param subject  the subject to read
+		 * @param property the property to read and check values
+		 * @return the value or the default property value if no value was found
+		 * @throws SailCompilerException if the value isn't a valid value for
+		 *                               this property
+		 */
+		public <T> Optional<T> searchPropertyValueOpt(Resource subject,
+				SailCompilerSchema.Property<T, ? extends SailCompilerSchema.ValueHandler<T>> property)
+				throws SailCompilerException {
+			return searchOneOpt(subject, property.getIri())
+					.map(v -> property.throwIfNotValidValue(v, getSailCompiler()));
+		}
+
+		/**
 		 * search for a property value in the graph
 		 *
 		 * @param subject  the subject to read
@@ -450,9 +466,7 @@ public class SailCompiler {
 		public <T> T searchPropertyValue(Resource subject,
 				SailCompilerSchema.Property<T, ? extends SailCompilerSchema.ValueHandler<T>> property)
 				throws SailCompilerException {
-			return searchOneOpt(subject, property.getIri())
-					.map(v -> property.throwIfNotValidValue(v, getSailCompiler()))
-					.orElseGet(property.getHandler()::defaultValue);
+			return searchPropertyValueOpt(subject, property).orElseGet(property.getHandler()::defaultValue);
 		}
 
 		/**

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SailCompilerSchema.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/SailCompilerSchema.java
@@ -4,7 +4,6 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 import java.io.FileOutputStream;
@@ -166,6 +165,16 @@ public class SailCompilerSchema {
 	 */
 	public static final IRI DIR_LOCATION = iri("dirLocation", "Describe a directory");
 	/**
+	 * mdlc:luceneMaxDocs
+	 */
+	public static final Property<Integer, NumberTypeValueHandler> LUCENE_MAX_DOCUMENTS_PROPERTY = propertyInt(
+			"luceneMaxDocs", "Describe the maximum amount of documents Lucene can retrieve");
+	/**
+	 * mdlc:luceneNumResults
+	 */
+	public static final Property<Integer, NumberTypeValueHandler> LUCENE_NUM_RESULTS_PROPERTY = propertyInt(
+			"luceneNumResults", "Describe the default amount of documents Lucene will retrieve");
+	/**
 	 * mdlc:storageMode
 	 */
 	public static final Property<IRI, IRITypeValueHandler> STORAGE_MODE_PROPERTY = propertyIri("storageMode",
@@ -323,6 +332,10 @@ public class SailCompilerSchema {
 
 	private static Property<String, StringTypeValueHandler> propertyStr(String name, String desc, String defaultValue) {
 		return property(name, desc, new StringTypeValueHandler(defaultValue));
+	}
+
+	private static Property<Integer, NumberTypeValueHandler> propertyInt(String name, String desc) {
+		return propertyInt(name, desc, 0);
 	}
 
 	private static Property<Integer, NumberTypeValueHandler> propertyInt(String name, String desc, int defaultValue) {

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/sail/LuceneSailCompiler.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/sail/LuceneSailCompiler.java
@@ -58,6 +58,11 @@ public class LuceneSailCompiler extends LinkedSailCompiler {
 		reader.searchOneOpt(rnode, SailCompilerSchema.DIR_LOCATION).map(reader.getSailCompiler()::asLitStringPath)
 				.ifPresent(builder::withDir);
 
+		reader.searchPropertyValueOpt(rnode, SailCompilerSchema.LUCENE_MAX_DOCUMENTS_PROPERTY)
+				.ifPresent(builder::withMaxDocs);
+		reader.searchPropertyValueOpt(rnode, SailCompilerSchema.LUCENE_NUM_RESULTS_PROPERTY)
+				.ifPresent(builder::withDefaultNumDocs);
+
 		reader.searchOneOpt(rnode, SailCompilerSchema.LUCENE_TYPE_REINDEX_QUERY)
 				.map(reader.getSailCompiler()::asLitString).ifPresent(builder::withReindexQuery);
 

--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/utils/sail/helpers/LuceneSailBuilder.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/utils/sail/helpers/LuceneSailBuilder.java
@@ -50,6 +50,17 @@ public class LuceneSailBuilder {
 	}
 
 	/**
+	 * add a particular parameter
+	 *
+	 * @param key   parameter key
+	 * @param value parameter value
+	 * @return this
+	 */
+	public LuceneSailBuilder withParameter(String key, Object value) {
+		return withParameter(key, String.valueOf(value));
+	}
+
+	/**
 	 * set the id of the sail
 	 *
 	 * @param id the id of the store
@@ -77,6 +88,26 @@ public class LuceneSailBuilder {
 	 */
 	public LuceneSailBuilder withDir(String dir) {
 		return withParameter(LuceneSail.LUCENE_DIR_KEY, dir);
+	}
+
+	/**
+	 * set the max documents in a query
+	 *
+	 * @param count count
+	 * @return this
+	 */
+	public LuceneSailBuilder withMaxDocs(int count) {
+		return withParameter(LuceneSail.MAX_DOCUMENTS_KEY, count);
+	}
+
+	/**
+	 * set the default number of documents in a query
+	 *
+	 * @param count count
+	 * @return this
+	 */
+	public LuceneSailBuilder withDefaultNumDocs(int count) {
+		return withParameter(LuceneSail.DEFAULT_NUM_DOCS_KEY, count);
 	}
 
 	/**

--- a/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/compiler/SailCompilerTest.java
+++ b/qendpoint-store/src/test/java/com/the_qa_company/qendpoint/compiler/SailCompilerTest.java
@@ -313,6 +313,18 @@ public class SailCompilerTest {
 	}
 
 	@Test
+	public void loadModel6Test() throws IOException, SailCompiler.SailCompilerException {
+		LoadData data = loadFile("model/model_example6.ttl");
+
+		assertLuceneSail(data.sail, SailTest.NAMESPACE + "luceneIndex1",
+				data.compiler.parseDir("${locationNative}lucene1"), null);
+
+		LuceneSail lc = (LuceneSail) data.sail;
+		Assert.assertEquals("1000000", lc.getParameter(LuceneSail.MAX_DOCUMENTS_KEY));
+		Assert.assertEquals("5000", lc.getParameter(LuceneSail.DEFAULT_NUM_DOCS_KEY));
+	}
+
+	@Test
 	public void dirCompileTest() throws SailCompiler.SailCompilerException {
 		SailCompiler compiler = new SailCompiler();
 		compiler.registerDirString("myKey", "my cat");

--- a/qendpoint-store/src/test/resources/model/model_example6.ttl
+++ b/qendpoint-store/src/test/resources/model/model_example6.ttl
@@ -1,0 +1,13 @@
+@prefix mdlc: <http://the-qa-company.com/modelcompiler/> .
+@prefix my: <http://example.org/> .
+@prefix search: <http://www.openrdf.org/contrib/lucenesail#> .
+
+mdlc:main mdlc:node my:lucenesail1 .
+
+my:lucenesail1 mdlc:type mdlc:luceneNode ;
+               search:indexid my:luceneIndex1 ;
+               mdlc:dirLocation "${locationNative}lucene1"^^mdlc:parsedString ;
+               mdlc:luceneMaxDocs 1000000 ;
+               mdlc:luceneNumResults 5000 ;
+               mdlc:luceneEvalMode "NATIVE".
+


### PR DESCRIPTION
Issue resolved (if any): #485 

Description of this pull request:

Update rdf4j to 5.1.0

add the 2 new document options to the compiler:

- `mdlc:luceneMaxDocs` : Same value as `LuceneSail#MAX_DOCUMENTS_KEY`
- `mdlc:luceneNumResults` : Same value as `LuceneSail#DEFAULT_NUM_DOCS_KEY`

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
