### PR TITLE
GH-537 Add lucene index id to logs when reindexing

### DIFF
--- a/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/CompiledSail.java
+++ b/qendpoint-store/src/main/java/com/the_qa_company/qendpoint/compiler/CompiledSail.java
@@ -253,6 +253,11 @@ public class CompiledSail extends SailWrapper {
 			NotifyingSail oldSail = sail.getBaseSail();
 			try {
 				sail.setBaseSail(source);
+				String indexId = sail.getParameter(LuceneSail.INDEX_ID);
+				if (indexId == null || indexId.isEmpty()) {
+					indexId = "no id";
+				}
+				logger.info("Reindexing sail: " + indexId);
 				sail.reindex();
 			} finally {
 				sail.setBaseSail(oldSail);


### PR DESCRIPTION
Issue resolved (if any): #537 

Description of this pull request:

Add lucene index id log when reindexing

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
