### PR TITLE
GH-605 Fix SPARQL formatting issues

### DIFF
--- a/qendpoint-frontend/src/components/SparqlEndpoint/index.tsx
+++ b/qendpoint-frontend/src/components/SparqlEndpoint/index.tsx
@@ -15,7 +15,8 @@ import '@triply/yasgui/build/yasgui.min.css'
 
 import s from './index.module.scss'
 
-const spfmt = require('sparql-formatter')
+// @ts-ignore
+import { spfmt } from 'sparql-formatter'
 
 Yasgui.Yasr.registerPlugin('QueryPlanPlugin', QueryPlanPlugin as any)
 interface ExportedYasguiTab {
@@ -57,9 +58,6 @@ export default function SparqlEndpoint () {
     setRequest: setPrefixesRequest
   } = prefixesReq
 
-  // Format request
-  const [tabToFormat, setTabToFormat] = useState<string>()
-
   const checkPrefixes = useCallback(() => {
     setPrefixesRequest(fetch(`${config.apiBase}/api/endpoint/prefixes`))
   }, [setPrefixesRequest])
@@ -88,20 +86,16 @@ export default function SparqlEndpoint () {
 
   /** Called when the user presses the button "format" */
   const onClickFormat = () => {
-    const query = yasguiRef.current?.getTab()?.getQuery()
-    const tabId = yasguiRef.current?.getTab()?.getId()
+    const tab = yasguiRef.current?.getTab()
+    const query = tab?.getQuery()
     // Check validity
-    if (query === undefined || tabId === undefined) {
+    if (tab === undefined || query === undefined) {
       enqueueSnackbar('No query to format', { variant: 'warning' })
       return
     }
-    // Save the tab to format and make the request
-    setTabToFormat(tabId)
 
     const formatted = spfmt(query) as string
 
-    const tab = yasguiRef.current?.getTab(tabToFormat)
-    if (tab === undefined) return // Handle only if the tab is still open
     // Set the query
     tab.setQuery(formatted)
   }


### PR DESCRIPTION
Issue resolved (if any): #605 

Description of this pull request:

Fix formatting issue by removing the async part (it was there to use an online formatter, but it was a stupid idea)

---

Please check all the lines before posting the pull request:

- [x] I've created tests for all my changes
- [x] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [x] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [x] All my commits have relevant names
- [x] I've squashed my commits (if necessary)
