### PR TITLE
add retry logic for deleting files

### DIFF
--- a/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/io/IOUtil.java
+++ b/qendpoint-core/src/main/java/com/the_qa_company/qendpoint/core/util/io/IOUtil.java
@@ -920,29 +920,56 @@ public class IOUtil {
 	 * @throws IOException io exception
 	 */
 	public static void deleteDirRecurse(Path path) throws IOException {
-		Files.walkFileTree(path, new FileVisitor<>() {
-			@Override
-			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-				return FileVisitResult.CONTINUE;
-			}
+        Files.walkFileTree(path, new FileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                return FileVisitResult.CONTINUE;
+            }
 
-			@Override
-			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-				Files.delete(file);
-				return FileVisitResult.CONTINUE;
-			}
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                deleteWithRetry(file);
+                return FileVisitResult.CONTINUE;
+            }
 
-			@Override
-			public FileVisitResult visitFileFailed(Path file, IOException exc) {
-				return FileVisitResult.TERMINATE;
-			}
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                // Log the failure, decide if you want to terminate or continue
+                System.err.println("Failed to visit file: " + file + ", error: " + exc.getMessage());
+                return FileVisitResult.TERMINATE; // Or CONTINUE, depending on desired behavior
+            }
 
-			@Override
-			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-				Files.delete(dir);
-				return FileVisitResult.CONTINUE;
-			}
-		});
-	}
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                deleteWithRetry(dir);
+                return FileVisitResult.CONTINUE;
+            }
+
+            private void deleteWithRetry(Path targetPath) throws IOException {
+                final int MAX_RETRIES = 5;
+                final long RETRY_DELAY_MS = 100; // 100 milliseconds
+
+                for (int i = 0; i < MAX_RETRIES; i++) {
+                    try {
+                        Files.delete(targetPath);
+                        return; // Success, exit retry loop
+                    } catch (FileSystemException e) {
+                        if (e.getMessage().contains("Device or resource busy") || e.getMessage().contains("Directory not empty")) {
+                            System.err.println("Attempt " + (i + 1) + " to delete " + targetPath + " failed: " + e.getMessage() + ". Retrying...");
+                            try {
+                                Thread.sleep(RETRY_DELAY_MS);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                throw new IOException("Deletion interrupted for " + targetPath, ie);
+                            }
+                        } else {
+                            throw e; // Re-throw other FileSystemExceptions immediately
+                        }
+                    }
+                }
+                throw new IOException("Failed to delete " + targetPath + " after " + MAX_RETRIES + " retries.");
+            }
+        });
+    }
 
 }


### PR DESCRIPTION
Issue resolved (if any): # <!-- issue number -->

Description of this pull request:

Retry logic for deleting files. especially useful for NFS based storage systems. 

---

Please check all the lines before posting the pull request:

- [ ] I've created tests for all my changes
- [ ] My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- [ ] I've applied the code formatter (`mvn formatter:format` on the backend, `npm run format` on the frontend) before posting my pull request, `mvn formatter:validate` to validate the formatting on the backend, `npm run validate` on the frontend
- [ ] All my commits have relevant names
- [ ] I've squashed my commits (if necessary)
